### PR TITLE
feature: Naver 로그인 구현

### DIFF
--- a/CatchMate/app/build.gradle.kts
+++ b/CatchMate/app/build.gradle.kts
@@ -12,6 +12,8 @@ android {
     namespace = "com.catchmate.android"
 
     val kakaoNativeAppKey = properties["kakao_native_app_key"] as? String ?: ""
+    val naverClientId = properties["naver_client_id"] as? String ?: ""
+    val naverClientSecret = properties["naver_client_secret"] as? String ?: ""
 
     defaultConfig {
         applicationId = "com.catchmate.android"
@@ -19,6 +21,8 @@ android {
         versionName = "1.0"
 
         buildConfigField("String", "KAKAO_NATIVE_APP_KEY", kakaoNativeAppKey)
+        buildConfigField("String", "NAVER_CLIENT_ID", naverClientId)
+        buildConfigField("String", "NAVER_CLIENT_SECRET", naverClientSecret)
         manifestPlaceholders["kakaoNativeAppKeyManifest"] = properties["kakao_native_app_key_manifest"] as String
     }
 
@@ -33,4 +37,5 @@ dependencies {
     implementation(project(":presentation"))
 
     implementation(libs.kakao.user)
+    implementation(libs.naver.user)
 }

--- a/CatchMate/app/src/main/java/com/catchmate/android/Application.kt
+++ b/CatchMate/app/src/main/java/com/catchmate/android/Application.kt
@@ -2,6 +2,7 @@ package com.catchmate.android
 
 import android.app.Application
 import com.kakao.sdk.common.KakaoSdk
+import com.navercorp.nid.NaverIdLoginSDK
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
@@ -11,5 +12,13 @@ class Application : Application() {
 
         // kakao sdk 초기화
         KakaoSdk.init(this, "${BuildConfig.KAKAO_NATIVE_APP_KEY}")
+
+        // naver sdk 초기화
+        NaverIdLoginSDK.initialize(
+            this,
+            "${BuildConfig.NAVER_CLIENT_ID}",
+            "${BuildConfig.NAVER_CLIENT_SECRET}",
+            "CatchMate",
+        )
     }
 }

--- a/CatchMate/data/build.gradle.kts
+++ b/CatchMate/data/build.gradle.kts
@@ -12,4 +12,5 @@ dependencies {
     implementation(project(":domain"))
 
     implementation(libs.kakao.user)
+    implementation(libs.naver.user)
 }

--- a/CatchMate/data/src/main/java/com/catchmate/data/datasource/local/NaverLoginDataSource.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/datasource/local/NaverLoginDataSource.kt
@@ -1,0 +1,72 @@
+package com.catchmate.data.datasource.local
+
+import android.content.Context
+import android.util.Log
+import com.navercorp.nid.NaverIdLoginSDK
+import com.navercorp.nid.oauth.NidOAuthLogin
+import com.navercorp.nid.oauth.OAuthLoginCallback
+import com.navercorp.nid.profile.NidProfileCallback
+import com.navercorp.nid.profile.data.NidProfileResponse
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+class NaverLoginDataSource
+    @Inject
+    constructor(
+        @ApplicationContext private val context: Context,
+    ) {
+        fun loginWithNaver() {
+            val nidProfileCallback =
+                object : NidProfileCallback<NidProfileResponse> {
+                    override fun onError(
+                        errorCode: Int,
+                        message: String,
+                    ) {
+                        onFailure(errorCode, message)
+                    }
+
+                    override fun onFailure(
+                        httpStatus: Int,
+                        message: String,
+                    ) {
+                        loginFail()
+                    }
+
+                    override fun onSuccess(result: NidProfileResponse) {
+                        if (result.profile != null) {
+                            Log.d("NaverInfoSuccess", "providerId : ${result.profile?.id} profile : ${result.profile?.profileImage}")
+                        }
+                    }
+                }
+
+            val oAuthLoginCallback =
+                object : OAuthLoginCallback {
+                    override fun onError(
+                        errorCode: Int,
+                        message: String,
+                    ) {
+                        onFailure(errorCode, message)
+                    }
+
+                    override fun onFailure(
+                        httpStatus: Int,
+                        message: String,
+                    ) {
+                        loginFail()
+                    }
+
+                    override fun onSuccess() {
+                        Log.d("NaverLoginSuccess", "네이버 로그인 성공")
+                        NidOAuthLogin().callProfileApi(nidProfileCallback)
+                    }
+                }
+
+            NaverIdLoginSDK.authenticate(context, oAuthLoginCallback)
+        }
+
+        private fun loginFail() {
+            val errorCode = NaverIdLoginSDK.getLastErrorCode().code
+            val errorDescription = NaverIdLoginSDK.getLastErrorDescription()
+            Log.e("NaverLoginFail", "errorCode:$errorCode errorDescription:$errorDescription")
+        }
+    }

--- a/CatchMate/data/src/main/java/com/catchmate/data/repository/LoginRepositoryImpl.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/repository/LoginRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.catchmate.data.repository
 
 import com.catchmate.data.datasource.local.KakaoLoginDataSource
+import com.catchmate.data.datasource.local.NaverLoginDataSource
 import com.catchmate.domain.repository.LoginRepository
 import javax.inject.Inject
 
@@ -8,8 +9,13 @@ class LoginRepositoryImpl
     @Inject
     constructor(
         private val kakaoLoginDataSource: KakaoLoginDataSource,
+        private val naverLoginDataSource: NaverLoginDataSource,
     ) : LoginRepository {
         override fun loginWithKakao() {
             kakaoLoginDataSource.loginWithKakao()
+        }
+
+        override fun loginWithNaver() {
+            naverLoginDataSource.loginWithNaver()
         }
     }

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/repository/LoginRepository.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/repository/LoginRepository.kt
@@ -2,4 +2,5 @@ package com.catchmate.domain.repository
 
 interface LoginRepository {
     fun loginWithKakao()
+    fun loginWithNaver()
 }

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/repository/LoginRepository.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/repository/LoginRepository.kt
@@ -2,5 +2,6 @@ package com.catchmate.domain.repository
 
 interface LoginRepository {
     fun loginWithKakao()
+
     fun loginWithNaver()
 }

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/usecase/LoginUseCase.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/usecase/LoginUseCase.kt
@@ -11,4 +11,8 @@ class LoginUseCase
         fun loginWithKakao() {
             loginRepository.loginWithKakao()
         }
+
+        fun loginWithNaver() {
+            loginRepository.loginWithNaver()
+        }
     }

--- a/CatchMate/gradle/libs.versions.toml
+++ b/CatchMate/gradle/libs.versions.toml
@@ -32,6 +32,9 @@ circleimageview = "3.1.0"
 # Kakao
 kakao = "2.20.3"
 
+# Naver
+naver = "5.8.0"
+
 [libraries]
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "android-gradle-plugin" }
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -61,6 +64,8 @@ hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref
 hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
 
 kakao-user = { group = "com.kakao.sdk", name = "v2-user", version.ref = "kakao" }
+
+naver-user = { group = "com.navercorp.nid", name = "oauth", version.ref = "naver" }
 
 [plugins]
 com-android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/login/LoginFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/login/LoginFragment.kt
@@ -32,6 +32,7 @@ class LoginFragment : Fragment() {
     ) {
         super.onViewCreated(view, savedInstanceState)
         initKakaoLoginBtn()
+        initNaverLoginBtn()
     }
 
     override fun onDestroyView() {
@@ -42,6 +43,12 @@ class LoginFragment : Fragment() {
     private fun initKakaoLoginBtn() {
         binding.btnLoginKakao.setOnClickListener {
             loginViewModel.kakaoLogin()
+        }
+    }
+
+    private fun initNaverLoginBtn() {
+        binding.imgbtnLoginNaver.setOnClickListener {
+            loginViewModel.naverLogin()
         }
     }
 }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/viewmodel/LoginViewModel.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/viewmodel/LoginViewModel.kt
@@ -24,4 +24,10 @@ class LoginViewModel
                 loginUseCase.loginWithKakao()
             }
         }
+
+        fun naverLogin() {
+            viewModelScope.launch {
+                loginUseCase.loginWithNaver()
+            }
+        }
     }


### PR DESCRIPTION
## 관련 이슈
- Related #15 
<br>

## 작업 내용
- BuildConfig에 naver client id, secret 숨김
- 네이버 로그인 성공 여부에 따라 계정 정보 받아오는 콜백 호출
- 버튼 클릭 시 네이버 로그인
<br>

## 참고 사항
- response, request model 생성 및 서버 연결은 추후 도메인 생성 시 예정
<br>
