### PR TITLE
feature: 게시글 등록 기능 구현

### DIFF
--- a/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/BoardWriteService.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/BoardWriteService.kt
@@ -1,0 +1,16 @@
+package com.catchmate.data.datasource.remote
+
+import com.catchmate.data.dto.BoardWriteRequestDTO
+import com.catchmate.data.dto.BoardWriteResponseDTO
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.Header
+import retrofit2.http.POST
+
+interface BoardWriteService {
+    @POST("board/write")
+    suspend fun postBoardWrite(
+        @Header("AccessToken") accessToken: String,
+        @Body boardWriteRequestDTO: BoardWriteRequestDTO,
+    ): Response<BoardWriteResponseDTO?>
+}

--- a/CatchMate/data/src/main/java/com/catchmate/data/di/BoardWriteModule.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/di/BoardWriteModule.kt
@@ -1,0 +1,15 @@
+package com.catchmate.data.di
+
+import com.catchmate.data.repository.BoardWriteRepositoryImpl
+import com.catchmate.domain.repository.BoardWriteRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+object BoardWriteModule {
+    @Provides
+    fun provideBoardWriteRepository(boardWriteRepositoryImpl: BoardWriteRepositoryImpl): BoardWriteRepository = boardWriteRepositoryImpl
+}

--- a/CatchMate/data/src/main/java/com/catchmate/data/dto/BoardWriteRequestDTO.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/dto/BoardWriteRequestDTO.kt
@@ -1,0 +1,14 @@
+package com.catchmate.data.dto
+
+data class BoardWriteRequestDTO(
+    val title: String,
+    val gameDate: String,
+    val location: String,
+    val homeTeam: String,
+    val awayTeam: String,
+    val maxPerson: Int,
+    val cheerTeam: String,
+    val preferGender: String? = null,
+    val preferAge: Int? = null,
+    val addInfo: String,
+)

--- a/CatchMate/data/src/main/java/com/catchmate/data/dto/BoardWriteResponseDTO.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/dto/BoardWriteResponseDTO.kt
@@ -1,0 +1,5 @@
+package com.catchmate.data.dto
+
+data class BoardWriteResponseDTO(
+    val boardId: Int,
+)

--- a/CatchMate/data/src/main/java/com/catchmate/data/mapper/BoardWriteMapper.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/mapper/BoardWriteMapper.kt
@@ -1,0 +1,27 @@
+package com.catchmate.data.mapper
+
+import com.catchmate.data.dto.BoardWriteRequestDTO
+import com.catchmate.data.dto.BoardWriteResponseDTO
+import com.catchmate.domain.model.BoardWriteRequest
+import com.catchmate.domain.model.BoardWriteResponse
+
+object BoardWriteMapper {
+    fun toBoardWriteRequestDTO(boardWriteRequest: BoardWriteRequest): BoardWriteRequestDTO =
+        BoardWriteRequestDTO(
+            title = boardWriteRequest.title,
+            gameDate = boardWriteRequest.gameDate,
+            location = boardWriteRequest.location,
+            homeTeam = boardWriteRequest.homeTeam,
+            awayTeam = boardWriteRequest.awayTeam,
+            maxPerson = boardWriteRequest.maxPerson,
+            cheerTeam = boardWriteRequest.cheerTeam,
+            preferGender = boardWriteRequest.preferGender,
+            preferAge = boardWriteRequest.preferAge,
+            addInfo = boardWriteRequest.addInfo,
+        )
+
+    fun toBoardWriteResponse(boardWriteResponseDTO: BoardWriteResponseDTO): BoardWriteResponse =
+        BoardWriteResponse(
+            boardId = boardWriteResponseDTO.boardId,
+        )
+}

--- a/CatchMate/data/src/main/java/com/catchmate/data/repository/BoardWriteRepositoryImpl.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/repository/BoardWriteRepositoryImpl.kt
@@ -13,7 +13,7 @@ class BoardWriteRepositoryImpl
     @Inject
     constructor(
         retrofitClient: RetrofitClient,
-    ): BoardWriteRepository {
+    ) : BoardWriteRepository {
         private val boardWriteApi = retrofitClient.createApi<BoardWriteService>()
 
         override suspend fun postBoardWrite(

--- a/CatchMate/data/src/main/java/com/catchmate/data/repository/BoardWriteRepositoryImpl.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/repository/BoardWriteRepositoryImpl.kt
@@ -1,0 +1,36 @@
+package com.catchmate.data.repository
+
+import android.util.Log
+import com.catchmate.data.datasource.remote.BoardWriteService
+import com.catchmate.data.datasource.remote.RetrofitClient
+import com.catchmate.data.mapper.BoardWriteMapper
+import com.catchmate.domain.model.BoardWriteRequest
+import com.catchmate.domain.model.BoardWriteResponse
+import com.catchmate.domain.repository.BoardWriteRepository
+import javax.inject.Inject
+
+class BoardWriteRepositoryImpl
+    @Inject
+    constructor(
+        retrofitClient: RetrofitClient,
+    ): BoardWriteRepository {
+        private val boardWriteApi = retrofitClient.createApi<BoardWriteService>()
+
+        override suspend fun postBoardWrite(
+            accessToken: String,
+            boardWriteRequest: BoardWriteRequest,
+        ): BoardWriteResponse? =
+            try {
+                val response = boardWriteApi.postBoardWrite(accessToken, BoardWriteMapper.toBoardWriteRequestDTO(boardWriteRequest))
+                if (response.isSuccessful) {
+                    Log.d("BoardWriteRepository", "통신 성공 : ${response.code()}")
+                    response.body()?.let { BoardWriteMapper.toBoardWriteResponse(it) } ?: throw Exception("Empty Response")
+                } else {
+                    Log.d("BoardWriteRepository", "통신 실패 : ${response.code()} - ${response.message()}")
+                    null
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+                null
+            }
+    }

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/model/BoardWriteRequest.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/model/BoardWriteRequest.kt
@@ -1,0 +1,14 @@
+package com.catchmate.domain.model
+
+data class BoardWriteRequest(
+    val title: String,
+    val gameDate: String,
+    val location: String,
+    val homeTeam: String,
+    val awayTeam: String,
+    val maxPerson: Int,
+    val cheerTeam: String,
+    val preferGender: String? = null,
+    val preferAge: Int? = null,
+    val addInfo: String,
+)

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/model/BoardWriteResponse.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/model/BoardWriteResponse.kt
@@ -1,0 +1,5 @@
+package com.catchmate.domain.model
+
+data class BoardWriteResponse(
+    val boardId: Int,
+)

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/repository/BoardWriteRepository.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/repository/BoardWriteRepository.kt
@@ -4,5 +4,8 @@ import com.catchmate.domain.model.BoardWriteRequest
 import com.catchmate.domain.model.BoardWriteResponse
 
 interface BoardWriteRepository {
-    suspend fun postBoardWrite(accessToken: String, boardWriteRequest: BoardWriteRequest): BoardWriteResponse?
+    suspend fun postBoardWrite(
+        accessToken: String,
+        boardWriteRequest: BoardWriteRequest,
+    ): BoardWriteResponse?
 }

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/repository/BoardWriteRepository.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/repository/BoardWriteRepository.kt
@@ -1,0 +1,8 @@
+package com.catchmate.domain.repository
+
+import com.catchmate.domain.model.BoardWriteRequest
+import com.catchmate.domain.model.BoardWriteResponse
+
+interface BoardWriteRepository {
+    suspend fun postBoardWrite(accessToken: String, boardWriteRequest: BoardWriteRequest): BoardWriteResponse?
+}

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/usecase/BoardWriteUseCase.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/usecase/BoardWriteUseCase.kt
@@ -1,0 +1,17 @@
+package com.catchmate.domain.usecase
+
+import com.catchmate.domain.model.BoardWriteRequest
+import com.catchmate.domain.model.BoardWriteResponse
+import com.catchmate.domain.repository.BoardWriteRepository
+import javax.inject.Inject
+
+class BoardWriteUseCase
+    @Inject
+    constructor(
+        private val boardWriteRepository: BoardWriteRepository,
+    ) {
+        suspend fun postBoardWrite(
+            accessToken: String,
+            boardWriteRequest: BoardWriteRequest,
+        ): BoardWriteResponse? = boardWriteRepository.postBoardWrite(accessToken, boardWriteRequest)
+    }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/interaction/OnCheerTeamSelectedListener.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/interaction/OnCheerTeamSelectedListener.kt
@@ -1,0 +1,5 @@
+package com.catchmate.presentation.interaction
+
+interface OnCheerTeamSelectedListener {
+    fun onCheerTeamSelected(cheerTeamName: String)
+}

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/interaction/OnDateTimeSelectedListener.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/interaction/OnDateTimeSelectedListener.kt
@@ -1,5 +1,8 @@
 package com.catchmate.presentation.interaction
 
 interface OnDateTimeSelectedListener {
-    fun onDateTimeSelected(date: String, time: String,)
+    fun onDateTimeSelected(
+        date: String,
+        time: String,
+    )
 }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/interaction/OnDateTimeSelectedListener.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/interaction/OnDateTimeSelectedListener.kt
@@ -1,0 +1,5 @@
+package com.catchmate.presentation.interaction
+
+interface OnDateTimeSelectedListener {
+    fun onDateTimeSelected(date: String, time: String,)
+}

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/interaction/OnPeopleCountSelectedListener.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/interaction/OnPeopleCountSelectedListener.kt
@@ -1,0 +1,5 @@
+package com.catchmate.presentation.interaction
+
+interface OnPeopleCountSelectedListener {
+    fun onPeopleCountSelected(count: Int)
+}

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/interaction/OnPlaceSelectedListener.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/interaction/OnPlaceSelectedListener.kt
@@ -1,0 +1,5 @@
+package com.catchmate.presentation.interaction
+
+interface OnPlaceSelectedListener {
+    fun onPlaceSelected(place: String)
+}

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/interaction/OnTeamSelectedListener.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/interaction/OnTeamSelectedListener.kt
@@ -1,0 +1,5 @@
+package com.catchmate.presentation.interaction
+
+interface OnTeamSelectedListener {
+    fun onTeamSelected(teamName: String, teamType: String)
+}

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/interaction/OnTeamSelectedListener.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/interaction/OnTeamSelectedListener.kt
@@ -1,5 +1,8 @@
 package com.catchmate.presentation.interaction
 
 interface OnTeamSelectedListener {
-    fun onTeamSelected(teamName: String, teamType: String)
+    fun onTeamSelected(
+        teamName: String,
+        teamType: String,
+    )
 }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/util/DateUtils.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/util/DateUtils.kt
@@ -17,7 +17,10 @@ object DateUtils {
         }
     }
 
-    fun formatGameDateTime(date: String, time: String): String {
+    fun formatGameDateTime(
+        date: String,
+        time: String,
+    ): String {
         return date + "T" + time + "00.000Z"
     }
 

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/util/DateUtils.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/util/DateUtils.kt
@@ -1,5 +1,9 @@
 package com.catchmate.presentation.util
 
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
 object DateUtils {
     fun formatBirthDate(inputDate: String): String {
         val year = inputDate.substring(0..1)
@@ -11,5 +15,21 @@ object DateUtils {
         } else {
             "19$year-$month-$day"
         }
+    }
+
+    fun formatGameDateTime(date: String, time: String): String {
+        return date + "T" + time + "00.000Z"
+    }
+
+    fun formatPlayDate(dateTime: String): String {
+        val (date, time) = dateTime.split("T")
+
+        val inputDateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+        val formattedDate: Date = inputDateFormat.parse(date)
+        val outputDateFormat = SimpleDateFormat("M월 d일 E요일", Locale.getDefault())
+
+        val formattedTime = time.substring(0, 5)
+
+        return outputDateFormat.format(formattedDate) + " | " + formattedTime
     }
 }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/util/DateUtils.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/util/DateUtils.kt
@@ -20,9 +20,7 @@ object DateUtils {
     fun formatGameDateTime(
         date: String,
         time: String,
-    ): String {
-        return date + "T" + time + "00.000Z"
-    }
+    ): String = date + "T" + time + "00.000Z"
 
     fun formatPlayDate(dateTime: String): String {
         val (date, time) = dateTime.split("T")

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/onboarding/SignupFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/onboarding/SignupFragment.kt
@@ -160,7 +160,8 @@ class SignupFragment : Fragment() {
                         before: Int,
                         count: Int,
                     ) {
-                        tvSignupNicknameCount.text = count.toString()
+                        val currentLength = s?.length ?: 0
+                        tvSignupNicknameCount.text = currentLength.toString()
                         runnable?.let { handler.removeCallbacks(it) }
                     }
 

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/AddPostFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/AddPostFragment.kt
@@ -28,6 +28,7 @@ class AddPostFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         initHeader()
         initFooter()
+        initAdditionalInfoEdt()
     }
 
     override fun onDestroyView() {
@@ -47,5 +48,18 @@ class AddPostFragment : Fragment() {
 
     private fun initFooter() {
         binding.layoutAddPostFooter.btnFooterOne.setText(R.string.post_complete)
+    }
+
+    private fun initAdditionalInfoEdt() {
+        binding.edtAddPostAdditionalInfo.setOnTouchListener { v, event ->
+            if (v.id == R.id.edt_add_post_additional_info) {
+                v.parent.requestDisallowInterceptTouchEvent(true)
+                if (event.action == android.view.MotionEvent.ACTION_UP) {
+                    v.parent.requestDisallowInterceptTouchEvent(false)
+                }
+            }
+            v.onTouchEvent(event)
+            true
+        }
     }
 }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/AddPostFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/AddPostFragment.kt
@@ -26,12 +26,18 @@ import com.google.android.material.chip.Chip
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class AddPostFragment : Fragment(), OnPeopleCountSelectedListener {
+class AddPostFragment :
+    Fragment(),
+    OnPeopleCountSelectedListener,
+    OnDateTimeSelectedListener,
+    OnTeamSelectedListener,
+    OnCheerTeamSelectedListener,
+    OnPlaceSelectedListener {
     private var _binding: FragmentAddPostBinding? = null
     val binding get() = _binding!!
 
-    private val addPostViewModel : AddPostViewModel by viewModels()
-    private val localDataViewModel : LocalDataViewMdoel by viewModels()
+    private val addPostViewModel: AddPostViewModel by viewModels()
+    private val localDataViewModel: LocalDataViewMdoel by viewModels()
 
     private lateinit var accessToken: String
     private lateinit var refreshToken: String
@@ -84,7 +90,8 @@ class AddPostFragment : Fragment(), OnPeopleCountSelectedListener {
         binding.layoutAddPostHeader.run {
             imgbtnHeaderTextBack.setOnClickListener {
                 val navOptions =
-                    NavOptions.Builder()
+                    NavOptions
+                        .Builder()
                         .setPopUpTo(R.id.addPostFragment, true)
                         .build()
                 findNavController().navigate(R.id.action_addPostFragment_to_homeFragment, null, navOptions)
@@ -131,7 +138,9 @@ class AddPostFragment : Fragment(), OnPeopleCountSelectedListener {
             setText(R.string.post_complete)
             setOnClickListener {
                 val title = binding.edtAddPostTitle.text.toString()
-                val peopleCount = binding.tvAddPostPeopleCount.text.toString().toInt()
+                val peopleCount = binding.tvAddPostPeopleCount.text
+                    .toString()
+                    .toInt()
                 val dateTime = addPostViewModel.gameDateTime.value.toString()
                 val homeTeam = addPostViewModel.homeTeamName.value.toString()
                 val awayTeam = addPostViewModel.awayTeamName.value.toString()
@@ -140,13 +149,26 @@ class AddPostFragment : Fragment(), OnPeopleCountSelectedListener {
                 val additionalInfo = binding.edtAddPostAdditionalInfo.text.toString()
                 val preferGender =
                     if (binding.chipgroupAddPostGender.checkedChipId != View.NO_ID) {
-                        binding.root.findViewById<Chip>(binding.chipgroupAddPostGender.checkedChipId).text.toString()
+                        binding.root.findViewById<Chip>(
+                            binding.chipgroupAddPostGender.checkedChipId,
+                        )
+                            .text
+                            .toString()
                     } else {
                         null
                     }
                 val preferAge =
                     if (binding.chipgroupAddPostAge.checkedChipIds.isNotEmpty()) {
-                        binding.root.findViewById<Chip>(binding.chipgroupAddPostAge.checkedChipIds[0]).text.toString().replace(Regex("[^0-9]"), "").toInt()
+                        binding.root.findViewById<Chip>(
+                            binding.chipgroupAddPostAge.checkedChipIds[0],
+                        )
+                            .text
+                            .toString()
+                            .replace(
+                                Regex("[^0-9]"),
+                                "",
+                            )
+                            .toInt()
                     } else {
                         null
                     }
@@ -228,12 +250,20 @@ class AddPostFragment : Fragment(), OnPeopleCountSelectedListener {
                 dateTimeBottomSheet.show(requireActivity().supportFragmentManager, dateTimeBottomSheet.tag)
             }
             tvAddPostHomeTeam.setOnClickListener {
-                val playTeamBottomSheet = PostPlayTeamBottomSheetFragment(addPostViewModel.homeTeamName.value, addPostViewModel.awayTeamName.value)
+                val playTeamBottomSheet =
+                    PostPlayTeamBottomSheetFragment(
+                        addPostViewModel.homeTeamName.value,
+                        addPostViewModel.awayTeamName.value,
+                    )
                 playTeamBottomSheet.setOnTeamSelectedListener(this@AddPostFragment, "home")
                 playTeamBottomSheet.show(requireActivity().supportFragmentManager, playTeamBottomSheet.tag)
             }
             tvAddPostAwayTeam.setOnClickListener {
-                val playTeamBottomSheet = PostPlayTeamBottomSheetFragment(addPostViewModel.awayTeamName.value, addPostViewModel.homeTeamName.value)
+                val playTeamBottomSheet =
+                    PostPlayTeamBottomSheetFragment(
+                        addPostViewModel.awayTeamName.value,
+                        addPostViewModel.homeTeamName.value,
+                    )
                 playTeamBottomSheet.setOnTeamSelectedListener(this@AddPostFragment, "away")
                 playTeamBottomSheet.show(requireActivity().supportFragmentManager, playTeamBottomSheet.tag)
             }
@@ -241,15 +271,17 @@ class AddPostFragment : Fragment(), OnPeopleCountSelectedListener {
                 if (addPostViewModel.homeTeamName.value == null || addPostViewModel.awayTeamName.value == null) {
                     return@setOnClickListener
                 }
-                val cheerTeamBottomSheet = PostCheerTeamBottomSheetFragment(
-                    addPostViewModel.homeTeamName.value!!,
-                    addPostViewModel.awayTeamName.value!!,
-                )
+                val cheerTeamBottomSheet =
+                    PostCheerTeamBottomSheetFragment(
+                        addPostViewModel.homeTeamName.value!!,
+                        addPostViewModel.awayTeamName.value!!,
+                    )
                 cheerTeamBottomSheet.setOnCheerTeamSelectedListener(this@AddPostFragment)
                 cheerTeamBottomSheet.show(requireActivity().supportFragmentManager, cheerTeamBottomSheet.tag)
             }
             tvAddPostPlace.setOnClickListener {
-                if (addPostViewModel.homeTeamName.value != getString(R.string.team_lotte_giants) && addPostViewModel.homeTeamName.value != getString(R.string.team_hanwha_eagles) && addPostViewModel.homeTeamName.value != getString(R.string.team_samsung_lions)) {
+                if (addPostViewModel.homeTeamName.value != getString(R.string.team_lotte_giants) && addPostViewModel.homeTeamName.value != getString(R.string.team_hanwha_eagles)
+                    && addPostViewModel.homeTeamName.value != getString(R.string.team_samsung_lions)) {
                     initPlaceTextView()
                     return@setOnClickListener
                 }
@@ -300,12 +332,18 @@ class AddPostFragment : Fragment(), OnPeopleCountSelectedListener {
         checkInputFieldsAreEmpty()
     }
 
-    override fun onDateTimeSelected(date: String, time: String) {
+    override fun onDateTimeSelected(
+        date: String,
+        time: String,
+    ) {
         addPostViewModel.setGameDate(DateUtils.formatGameDateTime(date, time))
         checkInputFieldsAreEmpty()
     }
 
-    override fun onTeamSelected(teamName: String, teamType: String) {
+    override fun onTeamSelected(
+        teamName: String,
+        teamType: String,
+    ) {
         if (teamType == "home") {
             addPostViewModel.setHomeTeamName(teamName)
         } else {

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/AddPostFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/AddPostFragment.kt
@@ -138,9 +138,10 @@ class AddPostFragment :
             setText(R.string.post_complete)
             setOnClickListener {
                 val title = binding.edtAddPostTitle.text.toString()
-                val peopleCount = binding.tvAddPostPeopleCount.text
-                    .toString()
-                    .toInt()
+                val peopleCount =
+                    binding.tvAddPostPeopleCount.text
+                        .toString()
+                        .toInt()
                 val dateTime = addPostViewModel.gameDateTime.value.toString()
                 val homeTeam = addPostViewModel.homeTeamName.value.toString()
                 val awayTeam = addPostViewModel.awayTeamName.value.toString()
@@ -149,26 +150,25 @@ class AddPostFragment :
                 val additionalInfo = binding.edtAddPostAdditionalInfo.text.toString()
                 val preferGender =
                     if (binding.chipgroupAddPostGender.checkedChipId != View.NO_ID) {
-                        binding.root.findViewById<Chip>(
-                            binding.chipgroupAddPostGender.checkedChipId,
-                        )
-                            .text
-                            .toString()
+                        binding.root
+                            .findViewById<Chip>(
+                                binding.chipgroupAddPostGender.checkedChipId,
+                            ).text
+                                .toString()
                     } else {
                         null
                     }
                 val preferAge =
                     if (binding.chipgroupAddPostAge.checkedChipIds.isNotEmpty()) {
-                        binding.root.findViewById<Chip>(
-                            binding.chipgroupAddPostAge.checkedChipIds[0],
-                        )
-                            .text
-                            .toString()
-                            .replace(
-                                Regex("[^0-9]"),
-                                "",
-                            )
-                            .toInt()
+                        binding.root
+                            .findViewById<Chip>(
+                                binding.chipgroupAddPostAge.checkedChipIds[0],
+                            ).text
+                                .toString()
+                                .replace(
+                                    Regex("[^0-9]"),
+                                    "",
+                                ).toInt()
                     } else {
                         null
                     }
@@ -280,8 +280,19 @@ class AddPostFragment :
                 cheerTeamBottomSheet.show(requireActivity().supportFragmentManager, cheerTeamBottomSheet.tag)
             }
             tvAddPostPlace.setOnClickListener {
-                if (addPostViewModel.homeTeamName.value != getString(R.string.team_lotte_giants) && addPostViewModel.homeTeamName.value != getString(R.string.team_hanwha_eagles)
-                    && addPostViewModel.homeTeamName.value != getString(R.string.team_samsung_lions)) {
+                if (addPostViewModel.homeTeamName.value !=
+                    getString(
+                        R.string.team_lotte_giants
+                    ) &&
+                    addPostViewModel.homeTeamName.value !=
+                    getString(
+                        R.string.team_hanwha_eagles
+                    ) &&
+                    addPostViewModel.homeTeamName.value !=
+                    getString(
+                        R.string.team_samsung_lions
+                    )
+                ) {
                     initPlaceTextView()
                     return@setOnClickListener
                 }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/AddPostFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/AddPostFragment.kt
@@ -1,16 +1,40 @@
 package com.catchmate.presentation.view.post
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.widget.doAfterTextChanged
+import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.navigation.NavOptions
+import androidx.navigation.fragment.findNavController
+import com.catchmate.domain.model.BoardWriteRequest
 import com.catchmate.presentation.R
 import com.catchmate.presentation.databinding.FragmentAddPostBinding
+import com.catchmate.presentation.interaction.OnCheerTeamSelectedListener
+import com.catchmate.presentation.interaction.OnDateTimeSelectedListener
+import com.catchmate.presentation.interaction.OnPeopleCountSelectedListener
+import com.catchmate.presentation.interaction.OnPlaceSelectedListener
+import com.catchmate.presentation.interaction.OnTeamSelectedListener
+import com.catchmate.presentation.util.DateUtils
+import com.catchmate.presentation.viewmodel.AddPostViewModel
+import com.catchmate.presentation.viewmodel.LocalDataViewMdoel
+import com.google.android.material.chip.Chip
+import dagger.hilt.android.AndroidEntryPoint
 
-class AddPostFragment : Fragment() {
+@AndroidEntryPoint
+class AddPostFragment : Fragment(), OnPeopleCountSelectedListener {
     private var _binding: FragmentAddPostBinding? = null
     val binding get() = _binding!!
+
+    private val addPostViewModel : AddPostViewModel by viewModels()
+    private val localDataViewModel : LocalDataViewMdoel by viewModels()
+
+    private lateinit var accessToken: String
+    private lateinit var refreshToken: String
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -26,9 +50,14 @@ class AddPostFragment : Fragment() {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        getTokens()
+        initViewModel()
         initHeader()
         initFooter()
         initAdditionalInfoEdt()
+        initBottomSheets()
+        initAgeChip()
+        initTitleTextView()
     }
 
     override fun onDestroyView() {
@@ -36,30 +65,262 @@ class AddPostFragment : Fragment() {
         _binding = null
     }
 
+    private fun getTokens() {
+        localDataViewModel.getAccessToken()
+        localDataViewModel.getRefreshToken()
+        localDataViewModel.accessToken.observe(viewLifecycleOwner) { accessToken ->
+            if (accessToken != null) {
+                this.accessToken = accessToken
+            }
+        }
+        localDataViewModel.refreshToken.observe(viewLifecycleOwner) { refreshToken ->
+            if (refreshToken != null) {
+                this.refreshToken = refreshToken
+            }
+        }
+    }
+
     private fun initHeader() {
         binding.layoutAddPostHeader.run {
             imgbtnHeaderTextBack.setOnClickListener {
-                // back
+                val navOptions =
+                    NavOptions.Builder()
+                        .setPopUpTo(R.id.addPostFragment, true)
+                        .build()
+                findNavController().navigate(R.id.action_addPostFragment_to_homeFragment, null, navOptions)
             }
             tvHeaderTextTitle.visibility = View.GONE
+            tvHeaderTextSub.visibility = View.VISIBLE
             tvHeaderTextSub.setText(R.string.temporary_storage)
         }
     }
 
+    private fun initViewModel() {
+        addPostViewModel.homeTeamName.observe(viewLifecycleOwner) { homeTeamName ->
+            if (homeTeamName != null) {
+                binding.tvAddPostHomeTeam.text = homeTeamName
+                if (homeTeamName != "자이언츠" && homeTeamName != "이글스" && homeTeamName != "라이온즈") {
+                    initPlaceTextView()
+                } else {
+                    binding.tvAddPostPlace.text = ""
+                }
+            }
+        }
+
+        addPostViewModel.awayTeamName.observe(viewLifecycleOwner) { awayTeamName ->
+            if (awayTeamName != null) {
+                binding.tvAddPostAwayTeam.text = awayTeamName
+            }
+        }
+
+        addPostViewModel.gameDateTime.observe(viewLifecycleOwner) { gameDateTime ->
+            if (gameDateTime != null) {
+                binding.tvAddPostGameDateTime.text = DateUtils.formatPlayDate(gameDateTime)
+            }
+        }
+
+        addPostViewModel.boardWriteResponse.observe(viewLifecycleOwner) { response ->
+            if (response != null) {
+                Log.e("boardWriteResponse", response.boardId.toString())
+            }
+        }
+    }
+
     private fun initFooter() {
-        binding.layoutAddPostFooter.btnFooterOne.setText(R.string.post_complete)
+        binding.layoutAddPostFooter.btnFooterOne.apply {
+            setText(R.string.post_complete)
+            setOnClickListener {
+                val title = binding.edtAddPostTitle.text.toString()
+                val peopleCount = binding.tvAddPostPeopleCount.text.toString().toInt()
+                val dateTime = addPostViewModel.gameDateTime.value.toString()
+                val homeTeam = addPostViewModel.homeTeamName.value.toString()
+                val awayTeam = addPostViewModel.awayTeamName.value.toString()
+                val cheerTeam = binding.tvAddPostCheerTeam.text.toString()
+                val place = binding.tvAddPostPlace.text.toString()
+                val additionalInfo = binding.edtAddPostAdditionalInfo.text.toString()
+                val preferGender =
+                    if (binding.chipgroupAddPostGender.checkedChipId != View.NO_ID) {
+                        binding.root.findViewById<Chip>(binding.chipgroupAddPostGender.checkedChipId).text.toString()
+                    } else {
+                        null
+                    }
+                val preferAge =
+                    if (binding.chipgroupAddPostAge.checkedChipIds.isNotEmpty()) {
+                        binding.root.findViewById<Chip>(binding.chipgroupAddPostAge.checkedChipIds[0]).text.toString().replace(Regex("[^0-9]"), "").toInt()
+                    } else {
+                        null
+                    }
+
+                val boardWriteRequest =
+                    BoardWriteRequest(
+                        title,
+                        dateTime,
+                        place,
+                        homeTeam,
+                        awayTeam,
+                        peopleCount,
+                        cheerTeam,
+                        preferGender,
+                        preferAge,
+                        additionalInfo,
+                    )
+
+                addPostViewModel.postBoardWrite(
+                    localDataViewModel.accessToken.value!!,
+                    boardWriteRequest,
+                )
+            }
+        }
+    }
+
+    private fun initTitleTextView() {
+        binding.edtAddPostTitle.doAfterTextChanged {
+            checkInputFieldsAreEmpty()
+        }
+    }
+
+    private fun initAgeChip() {
+        binding.chipgroupAddPostAge.setOnCheckedStateChangeListener { group, checkedIds ->
+            if (!checkedIds.contains(R.id.chip_add_post_age_regardless) && checkedIds.size == 5) {
+                group.clearCheck()
+                binding.chipAddPostAgeRegardless.isChecked = true
+            }
+            if (checkedIds.contains(R.id.chip_add_post_age_regardless) && checkedIds.size > 1) {
+                binding.chipAddPostAgeRegardless.isChecked = false
+            }
+        }
     }
 
     private fun initAdditionalInfoEdt() {
-        binding.edtAddPostAdditionalInfo.setOnTouchListener { v, event ->
-            if (v.id == R.id.edt_add_post_additional_info) {
-                v.parent.requestDisallowInterceptTouchEvent(true)
-                if (event.action == android.view.MotionEvent.ACTION_UP) {
-                    v.parent.requestDisallowInterceptTouchEvent(false)
+        binding.edtAddPostAdditionalInfo.apply {
+            setOnTouchListener { v, event ->
+                if (v.id == R.id.edt_add_post_additional_info) {
+                    v.parent.requestDisallowInterceptTouchEvent(true)
+                    if (event.action == android.view.MotionEvent.ACTION_UP) {
+                        v.parent.requestDisallowInterceptTouchEvent(false)
+                    }
                 }
+                v.onTouchEvent(event)
+                true
             }
-            v.onTouchEvent(event)
-            true
+
+            doOnTextChanged { text, _, _, _ ->
+                val currentL = text?.length ?: 0
+                binding.tvAddPostAdditionalInfoLetterCount.text = currentL.toString()
+            }
+
+            doAfterTextChanged {
+                checkInputFieldsAreEmpty()
+            }
         }
+    }
+
+    private fun initBottomSheets() {
+        binding.apply {
+            tvAddPostPeopleCount.setOnClickListener {
+                val peopleCountBottomSheet = PostHeadCountBottomSheetFragment()
+                peopleCountBottomSheet.setOnPeopleCountSelectedListener(this@AddPostFragment)
+                peopleCountBottomSheet.show(requireActivity().supportFragmentManager, peopleCountBottomSheet.tag)
+            }
+            tvAddPostGameDateTime.setOnClickListener {
+                val dateTimeBottomSheet = PostDateTimeBottomSheetFragment()
+                dateTimeBottomSheet.setOnDateTimeSelectedListener(this@AddPostFragment)
+                dateTimeBottomSheet.show(requireActivity().supportFragmentManager, dateTimeBottomSheet.tag)
+            }
+            tvAddPostHomeTeam.setOnClickListener {
+                val playTeamBottomSheet = PostPlayTeamBottomSheetFragment(addPostViewModel.homeTeamName.value, addPostViewModel.awayTeamName.value)
+                playTeamBottomSheet.setOnTeamSelectedListener(this@AddPostFragment, "home")
+                playTeamBottomSheet.show(requireActivity().supportFragmentManager, playTeamBottomSheet.tag)
+            }
+            tvAddPostAwayTeam.setOnClickListener {
+                val playTeamBottomSheet = PostPlayTeamBottomSheetFragment(addPostViewModel.awayTeamName.value, addPostViewModel.homeTeamName.value)
+                playTeamBottomSheet.setOnTeamSelectedListener(this@AddPostFragment, "away")
+                playTeamBottomSheet.show(requireActivity().supportFragmentManager, playTeamBottomSheet.tag)
+            }
+            tvAddPostCheerTeam.setOnClickListener {
+                if (addPostViewModel.homeTeamName.value == null || addPostViewModel.awayTeamName.value == null) {
+                    return@setOnClickListener
+                }
+                val cheerTeamBottomSheet = PostCheerTeamBottomSheetFragment(
+                    addPostViewModel.homeTeamName.value!!,
+                    addPostViewModel.awayTeamName.value!!,
+                )
+                cheerTeamBottomSheet.setOnCheerTeamSelectedListener(this@AddPostFragment)
+                cheerTeamBottomSheet.show(requireActivity().supportFragmentManager, cheerTeamBottomSheet.tag)
+            }
+            tvAddPostPlace.setOnClickListener {
+                if (addPostViewModel.homeTeamName.value != getString(R.string.team_lotte_giants) && addPostViewModel.homeTeamName.value != getString(R.string.team_hanwha_eagles) && addPostViewModel.homeTeamName.value != getString(R.string.team_samsung_lions)) {
+                    initPlaceTextView()
+                    return@setOnClickListener
+                }
+                val placeBottomSheet = PostPlaceBottomSheetFragment(addPostViewModel.homeTeamName.value!!)
+                placeBottomSheet.setOnPlaceSelectedListener(this@AddPostFragment)
+                placeBottomSheet.show(requireActivity().supportFragmentManager, placeBottomSheet.tag)
+            }
+        }
+    }
+
+    private fun initPlaceTextView() {
+        binding.tvAddPostPlace.text =
+            when (addPostViewModel.homeTeamName.value) {
+                getString(R.string.team_nc_dinos) -> getString(R.string.post_place_nc)
+                getString(R.string.team_ssg_landers) -> getString(R.string.post_place_ssg)
+                getString(R.string.team_doosan_bears) -> getString(R.string.post_place_doosan_lg)
+                getString(R.string.team_kt_wiz) -> getString(R.string.post_place_kt)
+                getString(R.string.team_kia_tigers) -> getString(R.string.post_place_kia)
+                getString(R.string.team_lg_twins) -> getString(R.string.post_place_doosan_lg)
+                else -> getString(R.string.post_place_kiwoom)
+            }
+    }
+
+    private fun checkInputFieldsAreEmpty() {
+        val title = binding.edtAddPostTitle.text.toString()
+        val peopleCount = binding.tvAddPostPeopleCount.text.toString()
+        val dateTime = addPostViewModel.gameDateTime.value.toString()
+        val homeTeam = addPostViewModel.homeTeamName.value.toString()
+        val awayTeam = addPostViewModel.awayTeamName.value.toString()
+        val cheerTeam = binding.tvAddPostCheerTeam.text.toString()
+        val place = binding.tvAddPostPlace.text.toString()
+        val additionalInfo = binding.edtAddPostAdditionalInfo.text.toString()
+        // 연령대 추후 로직 변경 시 적용
+
+        binding.layoutAddPostFooter.btnFooterOne.isEnabled =
+            title.isNotEmpty() &&
+            peopleCount.isNotEmpty() &&
+            dateTime.isNotEmpty() &&
+            homeTeam.isNotEmpty() &&
+            awayTeam.isNotEmpty() &&
+            cheerTeam.isNotEmpty() &&
+            place.isNotEmpty() &&
+            additionalInfo.isNotEmpty()
+    }
+
+    override fun onPeopleCountSelected(count: Int) {
+        binding.tvAddPostPeopleCount.text = count.toString()
+        checkInputFieldsAreEmpty()
+    }
+
+    override fun onDateTimeSelected(date: String, time: String) {
+        addPostViewModel.setGameDate(DateUtils.formatGameDateTime(date, time))
+        checkInputFieldsAreEmpty()
+    }
+
+    override fun onTeamSelected(teamName: String, teamType: String) {
+        if (teamType == "home") {
+            addPostViewModel.setHomeTeamName(teamName)
+        } else {
+            addPostViewModel.setAwayTeamName(teamName)
+        }
+        checkInputFieldsAreEmpty()
+    }
+
+    override fun onCheerTeamSelected(cheerTeamName: String) {
+        binding.tvAddPostCheerTeam.text = cheerTeamName
+        checkInputFieldsAreEmpty()
+    }
+
+    override fun onPlaceSelected(place: String) {
+        binding.tvAddPostPlace.text = place
+        checkInputFieldsAreEmpty()
     }
 }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/AddPostFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/AddPostFragment.kt
@@ -154,7 +154,7 @@ class AddPostFragment :
                             .findViewById<Chip>(
                                 binding.chipgroupAddPostGender.checkedChipId,
                             ).text
-                                .toString()
+                            .toString()
                     } else {
                         null
                     }
@@ -164,11 +164,11 @@ class AddPostFragment :
                             .findViewById<Chip>(
                                 binding.chipgroupAddPostAge.checkedChipIds[0],
                             ).text
-                                .toString()
-                                .replace(
-                                    Regex("[^0-9]"),
-                                    "",
-                                ).toInt()
+                            .toString()
+                            .replace(
+                                Regex("[^0-9]"),
+                                "",
+                            ).toInt()
                     } else {
                         null
                     }
@@ -282,15 +282,15 @@ class AddPostFragment :
             tvAddPostPlace.setOnClickListener {
                 if (addPostViewModel.homeTeamName.value !=
                     getString(
-                        R.string.team_lotte_giants
+                        R.string.team_lotte_giants,
                     ) &&
                     addPostViewModel.homeTeamName.value !=
                     getString(
-                        R.string.team_hanwha_eagles
+                        R.string.team_hanwha_eagles,
                     ) &&
                     addPostViewModel.homeTeamName.value !=
                     getString(
-                        R.string.team_samsung_lions
+                        R.string.team_samsung_lions,
                     )
                 ) {
                     initPlaceTextView()

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/PostCheerTeamBottomSheetFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/PostCheerTeamBottomSheetFragment.kt
@@ -28,7 +28,10 @@ class PostCheerTeamBottomSheetFragment(
         return binding.root
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
         super.onViewCreated(view, savedInstanceState)
         initTeamToggleCheckButtonResources(homeTeam, binding.ttcbvPostCheerTeamHome)
         initTeamToggleCheckButtonResources(awayTeam, binding.ttcbvPostCheerTeamAway)
@@ -45,7 +48,7 @@ class PostCheerTeamBottomSheetFragment(
         val teamButtons: List<TeamToggleCheckButtonView> =
             listOf(
                 binding.ttcbvPostCheerTeamHome,
-                binding.ttcbvPostCheerTeamAway
+                binding.ttcbvPostCheerTeamAway,
             )
 
         teamButtons.forEach { btn ->
@@ -81,7 +84,13 @@ class PostCheerTeamBottomSheetFragment(
 
     private fun initFooter() {
         binding.layoutFooterPostCheerTeam.btnFooterOne.setOnClickListener {
-            cheerTeamSelectedListener?.onCheerTeamSelected(selectedButton?.binding?.tvTeamToggleCheckButton?.text.toString())
+            cheerTeamSelectedListener?.onCheerTeamSelected(
+                selectedButton
+                    ?.binding
+                    ?.tvTeamToggleCheckButton
+                    ?.text
+                    .toString(),
+            )
             dismiss()
         }
     }
@@ -90,7 +99,10 @@ class PostCheerTeamBottomSheetFragment(
         cheerTeamSelectedListener = listener
     }
 
-    private fun initTeamToggleCheckButtonResources(teamName: String, buttonView: TeamToggleCheckButtonView) {
+    private fun initTeamToggleCheckButtonResources(
+        teamName: String,
+        buttonView: TeamToggleCheckButtonView,
+    ) {
         buttonView.binding.tvTeamToggleCheckButton.text = teamName
         when (teamName) {
             "다이노스" -> {

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/PostCheerTeamBottomSheetFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/PostCheerTeamBottomSheetFragment.kt
@@ -1,0 +1,148 @@
+package com.catchmate.presentation.view.post
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.catchmate.presentation.R
+import com.catchmate.presentation.databinding.FragmentPostCheerTeamBottomSheetBinding
+import com.catchmate.presentation.interaction.OnCheerTeamSelectedListener
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+
+class PostCheerTeamBottomSheetFragment(
+    val homeTeam: String,
+    val awayTeam: String,
+) : BottomSheetDialogFragment() {
+    private var _binding: FragmentPostCheerTeamBottomSheetBinding? = null
+    val binding get() = _binding!!
+
+    private var selectedButton: TeamToggleCheckButtonView? = null
+    private var cheerTeamSelectedListener: OnCheerTeamSelectedListener? = null
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View? {
+        _binding = FragmentPostCheerTeamBottomSheetBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initTeamToggleCheckButtonResources(homeTeam, binding.ttcbvPostCheerTeamHome)
+        initTeamToggleCheckButtonResources(awayTeam, binding.ttcbvPostCheerTeamAway)
+        initTeamButton()
+        initFooter()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun initTeamButton() {
+        val teamButtons: List<TeamToggleCheckButtonView> =
+            listOf(
+                binding.ttcbvPostCheerTeamHome,
+                binding.ttcbvPostCheerTeamAway
+            )
+
+        teamButtons.forEach { btn ->
+            btn.binding.toggleTeamToggleCheckButton.setOnCheckedChangeListener { buttonView, isChecked ->
+                btn.binding.cbTeamToggleCheckButton.isChecked = isChecked
+                if (isChecked) {
+                    selectedButton?.binding?.toggleTeamToggleCheckButton?.isChecked = false
+                    buttonView.isChecked = true
+                    selectedButton = btn
+                    binding.layoutFooterPostCheerTeam.btnFooterOne.isEnabled = true
+                } else {
+                    binding.layoutFooterPostCheerTeam.btnFooterOne.isEnabled = false
+                }
+            }
+
+            btn.binding.cbTeamToggleCheckButton.setOnCheckedChangeListener { buttonView, isChecked ->
+                btn.binding.toggleTeamToggleCheckButton.isChecked = isChecked
+                if (isChecked) {
+                    selectedButton?.binding?.cbTeamToggleCheckButton?.isChecked = false
+                    buttonView.isChecked = true
+                    selectedButton = btn
+                    binding.layoutFooterPostCheerTeam.btnFooterOne.isEnabled = true
+                } else {
+                    binding.layoutFooterPostCheerTeam.btnFooterOne.isEnabled = false
+                }
+            }
+
+            btn.setOnClickListener {
+                btn.binding.toggleTeamToggleCheckButton.isChecked = !btn.binding.toggleTeamToggleCheckButton.isChecked
+            }
+        }
+    }
+
+    private fun initFooter() {
+        binding.layoutFooterPostCheerTeam.btnFooterOne.setOnClickListener {
+            cheerTeamSelectedListener?.onCheerTeamSelected(selectedButton?.binding?.tvTeamToggleCheckButton?.text.toString())
+            dismiss()
+        }
+    }
+
+    fun setOnCheerTeamSelectedListener(listener: OnCheerTeamSelectedListener) {
+        cheerTeamSelectedListener = listener
+    }
+
+    private fun initTeamToggleCheckButtonResources(teamName: String, buttonView: TeamToggleCheckButtonView) {
+        buttonView.binding.tvTeamToggleCheckButton.text = teamName
+        when (teamName) {
+            "다이노스" -> {
+                buttonView.binding.apply {
+                    toggleTeamToggleCheckButton.setBackgroundResource(R.drawable.selector_nc_dinos_bg)
+                }
+            }
+            "라이온즈" -> {
+                buttonView.binding.apply {
+                    toggleTeamToggleCheckButton.setBackgroundResource(R.drawable.selector_samsung_lions_bg)
+                }
+            }
+            "랜더스" -> {
+                buttonView.binding.apply {
+                    toggleTeamToggleCheckButton.setBackgroundResource(R.drawable.selector_ssg_landers_bg)
+                }
+            }
+            "베어스" -> {
+                buttonView.binding.apply {
+                    toggleTeamToggleCheckButton.setBackgroundResource(R.drawable.selector_doosan_bears_bg)
+                }
+            }
+            "위즈" -> {
+                buttonView.binding.apply {
+                    toggleTeamToggleCheckButton.setBackgroundResource(R.drawable.selector_kt_wiz_bg)
+                }
+            }
+            "이글스" -> {
+                buttonView.binding.apply {
+                    toggleTeamToggleCheckButton.setBackgroundResource(R.drawable.selector_hanwha_eagles_bg)
+                }
+            }
+            "자이언츠" -> {
+                buttonView.binding.apply {
+                    toggleTeamToggleCheckButton.setBackgroundResource(R.drawable.selector_lotte_giants_bg)
+                }
+            }
+            "타이거즈" -> {
+                buttonView.binding.apply {
+                    toggleTeamToggleCheckButton.setBackgroundResource(R.drawable.selector_kia_tigers_bg)
+                }
+            }
+            "트윈스" -> {
+                buttonView.binding.apply {
+                    toggleTeamToggleCheckButton.setBackgroundResource(R.drawable.selector_lg_twins_bg)
+                }
+            }
+            else -> {
+                buttonView.binding.apply {
+                    toggleTeamToggleCheckButton.setBackgroundResource(R.drawable.selector_kiwoom_heroes_bg)
+                }
+            }
+        }
+    }
+}

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/PostDateTimeBottomSheetFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/PostDateTimeBottomSheetFragment.kt
@@ -1,19 +1,90 @@
 package com.catchmate.presentation.view.post
 
+import android.app.Dialog
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import com.catchmate.presentation.R
+import com.catchmate.presentation.databinding.FragmentPostDateTimeBottomSheetBinding
+import com.catchmate.presentation.interaction.OnDateTimeSelectedListener
+import com.catchmate.presentation.util.DateUtils
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.google.android.material.chip.Chip
 
 class PostDateTimeBottomSheetFragment : BottomSheetDialogFragment() {
+    private var _binding: FragmentPostDateTimeBottomSheetBinding? = null
+    val binding get() = _binding!!
+
+    private var dateTimeSelectedListener: OnDateTimeSelectedListener? = null
+    private var selectedDate: String = ""
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog = super.onCreateDialog(savedInstanceState) as BottomSheetDialog
+        val behavior = dialog.behavior
+        behavior.state = BottomSheetBehavior.STATE_EXPANDED
+        return dialog
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_post_date_time_bottom_sheet, container, false)
+        _binding = FragmentPostDateTimeBottomSheetBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+        initTimeChipGroup()
+        initFooter()
+        initCalendarView()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun initTimeChipGroup() {
+        binding.cgPostDateTime.setOnCheckedStateChangeListener { group, checkedIds ->
+            binding.layoutFooterPostDateTime.btnFooterOne.isEnabled = checkedIds.isNotEmpty()
+        }
+    }
+
+    private fun initCalendarView() {
+        binding.cvPostDateTime.setOnDateChangeListener { _, year, month, dayOfMonth ->
+            selectedDate = "$year-${String.format("%02d", month + 1)}-${String.format("%02d", dayOfMonth)}"
+            Log.d("selectedDate", selectedDate)
+        }
+    }
+
+    private fun initFooter() {
+        binding.layoutFooterPostDateTime.btnFooterOne.apply {
+            text = getString(R.string.complete)
+            setOnClickListener {
+                val checkedChipId = binding.cgPostDateTime.checkedChipId
+                if (checkedChipId == View.NO_ID) {
+                    return@setOnClickListener
+                }
+                val checkedChip = binding.root.findViewById<Chip>(checkedChipId)
+                dateTimeSelectedListener?.onDateTimeSelected(
+                    selectedDate,
+                    checkedChip.text.toString(),
+                )
+                dismiss()
+            }
+        }
+    }
+
+    fun setOnDateTimeSelectedListener(listener: OnDateTimeSelectedListener) {
+        dateTimeSelectedListener = listener
     }
 }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/PostDateTimeBottomSheetFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/PostDateTimeBottomSheetFragment.kt
@@ -9,7 +9,6 @@ import android.view.ViewGroup
 import com.catchmate.presentation.R
 import com.catchmate.presentation.databinding.FragmentPostDateTimeBottomSheetBinding
 import com.catchmate.presentation.interaction.OnDateTimeSelectedListener
-import com.catchmate.presentation.util.DateUtils
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/PostHeadCountBottomSheetFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/PostHeadCountBottomSheetFragment.kt
@@ -6,15 +6,17 @@ import android.view.View
 import android.view.ViewGroup
 import com.catchmate.presentation.R
 import com.catchmate.presentation.databinding.FragmentPostHeadCountBottomSheetBinding
+import com.catchmate.presentation.interaction.OnPeopleCountSelectedListener
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
 class PostHeadCountBottomSheetFragment : BottomSheetDialogFragment() {
     private var _binding: FragmentPostHeadCountBottomSheetBinding? = null
     val binding get() = _binding!!
 
+    private var peopleCountSelectedListener: OnPeopleCountSelectedListener? = null
+
     private val headCountArray =
         arrayOf(
-            "1명",
             "2명",
             "3명",
             "4명",
@@ -47,10 +49,18 @@ class PostHeadCountBottomSheetFragment : BottomSheetDialogFragment() {
         _binding = null
     }
 
+    fun setOnPeopleCountSelectedListener(listener: OnPeopleCountSelectedListener) {
+        peopleCountSelectedListener = listener
+    }
+
     private fun initFooterButton() {
         binding.layoutPostHeadCountFooter.btnFooterOne.run {
             isEnabled = true
-            setText(R.string.application)
+            setText(R.string.complete)
+            setOnClickListener {
+                peopleCountSelectedListener?.onPeopleCountSelected(binding.npPostHeadCount.value + 2)
+                dismiss()
+            }
         }
     }
 

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/PostPlaceBottomSheetFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/PostPlaceBottomSheetFragment.kt
@@ -1,19 +1,120 @@
 package com.catchmate.presentation.view.post
 
+import android.app.Dialog
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import com.catchmate.presentation.R
+import com.catchmate.presentation.databinding.FragmentPostPlaceBottomSheetBinding
+import com.catchmate.presentation.interaction.OnPlaceSelectedListener
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
-class PostPlaceBottomSheetFragment : BottomSheetDialogFragment() {
+class PostPlaceBottomSheetFragment(
+    val homeTeamName: String,
+) : BottomSheetDialogFragment() {
+    private var _binding: FragmentPostPlaceBottomSheetBinding? = null
+    val binding get() = _binding!!
+
+    private var selectedPlace: String = ""
+    private var placeSelectedListener: OnPlaceSelectedListener? = null
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog = super.onCreateDialog(savedInstanceState) as BottomSheetDialog
+        val behavior = dialog.behavior
+        behavior.state = BottomSheetBehavior.STATE_EXPANDED
+
+        return dialog
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_post_place_bottom_sheet, container, false)
+        _binding = FragmentPostPlaceBottomSheetBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+        initTextView()
+        initCheckBox()
+        initFooter()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun initTextView() {
+        when (homeTeamName) {
+            "자이언츠" -> {
+                binding.tvPostPlaceFirst.text = getString(R.string.post_place_lotte_first)
+                binding.tvPostPlaceSecond.text = getString(R.string.post_place_lotte_second)
+            }
+            "이글스" -> {
+                binding.tvPostPlaceFirst.text = getString(R.string.post_place_hanwha_first)
+                binding.tvPostPlaceSecond.text = getString(R.string.post_place_hanwha_second)
+            }
+            "라이온즈" -> {
+                binding.tvPostPlaceFirst.text = getString(R.string.post_place_samsung_first)
+                binding.tvPostPlaceSecond.text = getString(R.string.post_place_samsung_second)
+            }
+        }
+
+        binding.layoutPostPlaceFirst.setOnClickListener {
+            binding.cbPostPlaceFirst.isChecked = !binding.cbPostPlaceFirst.isChecked
+        }
+
+        binding.layoutPostPlaceSecond.setOnClickListener {
+            binding.cbPostPlaceSecond.isChecked = !binding.cbPostPlaceSecond.isChecked
+        }
+    }
+
+    private fun initCheckBox() {
+        binding.apply {
+            cbPostPlaceFirst.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) {
+                    cbPostPlaceSecond.isChecked = false
+                    selectedPlace = tvPostPlaceFirst.text.toString()
+                    layoutPostPlaceFooter.btnFooterOne.isEnabled = true
+                } else {
+                    selectedPlace = ""
+                    layoutPostPlaceFooter.btnFooterOne.isEnabled = false
+                }
+            }
+
+            cbPostPlaceSecond.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) {
+                    cbPostPlaceFirst.isChecked = false
+                    selectedPlace = tvPostPlaceSecond.text.toString()
+                    layoutPostPlaceFooter.btnFooterOne.isEnabled = true
+                } else {
+                    selectedPlace = ""
+                    layoutPostPlaceFooter.btnFooterOne.isEnabled = false
+                }
+            }
+        }
+    }
+
+    private fun initFooter() {
+        binding.layoutPostPlaceFooter.btnFooterOne.apply {
+            setText(R.string.complete)
+            setOnClickListener {
+                placeSelectedListener?.onPlaceSelected(selectedPlace)
+                dismiss()
+            }
+        }
+    }
+
+    fun setOnPlaceSelectedListener(listener: OnPlaceSelectedListener) {
+        placeSelectedListener = listener
     }
 }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/PostPlaceBottomSheetFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/PostPlaceBottomSheetFragment.kt
@@ -40,7 +40,7 @@ class PostPlaceBottomSheetFragment(
 
     override fun onViewCreated(
         view: View,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
         initTextView()

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/PostPlayTeamBottomSheetFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/PostPlayTeamBottomSheetFragment.kt
@@ -118,13 +118,23 @@ class PostPlayTeamBottomSheetFragment(
         binding.layoutFooterPlayTeamBottomSheet.btnFooterOne.apply {
             text = getString(R.string.complete)
             setOnClickListener {
-                teamSelectedListener?.onTeamSelected(selectedButton?.binding?.tvTeamToggleCheckButton?.text.toString(), teamType)
+                teamSelectedListener?.onTeamSelected(
+                    selectedButton
+                    ?.binding
+                    ?.tvTeamToggleCheckButton
+                    ?.text
+                    .toString(),
+                    teamType,
+                )
                 dismiss()
             }
         }
     }
 
-    fun setOnTeamSelectedListener(listener: OnTeamSelectedListener, teamType: String) {
+    fun setOnTeamSelectedListener(
+        listener: OnTeamSelectedListener,
+        teamType: String,
+    ) {
         teamSelectedListener = listener
         this.teamType = teamType
     }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/PostPlayTeamBottomSheetFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/PostPlayTeamBottomSheetFragment.kt
@@ -120,10 +120,10 @@ class PostPlayTeamBottomSheetFragment(
             setOnClickListener {
                 teamSelectedListener?.onTeamSelected(
                     selectedButton
-                    ?.binding
-                    ?.tvTeamToggleCheckButton
-                    ?.text
-                    .toString(),
+                        ?.binding
+                        ?.tvTeamToggleCheckButton
+                        ?.text
+                        .toString(),
                     teamType,
                 )
                 dismiss()

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/PostPlayTeamBottomSheetFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/PostPlayTeamBottomSheetFragment.kt
@@ -1,0 +1,96 @@
+package com.catchmate.presentation.view.post
+
+import android.app.Dialog
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.constraintlayout.widget.ConstraintLayout
+import com.catchmate.presentation.R
+import com.catchmate.presentation.databinding.FragmentPostPlayTeamBottomSheetBinding
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+
+class PostPlayTeamBottomSheetFragment : BottomSheetDialogFragment() {
+    private var _binding: FragmentPostPlayTeamBottomSheetBinding? = null
+    val binding get() = _binding!!
+
+    var selectedButton: TeamToggleCheckButtonView? = null
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog = super.onCreateDialog(savedInstanceState) as BottomSheetDialog
+        val behavior = dialog.behavior
+        behavior.state = BottomSheetBehavior.STATE_EXPANDED
+
+        return dialog
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View? {
+        _binding = FragmentPostPlayTeamBottomSheetBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initTeamButtons()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun initTeamButtons() {
+        val teamToggleCheckButtons: List<TeamToggleCheckButtonView> =
+            listOf(
+                binding.ttcbvPlayTeamBottomSheetNc,
+                binding.ttcbvPlayTeamBottomSheetSsg,
+                binding.ttcbvPlayTeamBottomSheetSamsung,
+                binding.ttcbvPlayTeamBottomSheetDoosan,
+                binding.ttcbvPlayTeamBottomSheetKt,
+                binding.ttcbvPlayTeamBottomSheetHanwha,
+                binding.ttcbvPlayTeamBottomSheetKia,
+                binding.ttcbvPlayTeamBottomSheetLotte,
+                binding.ttcbvPlayTeamBottomSheetLg,
+                binding.ttcbvPlayTeamBottomSheetKiwoom,
+            )
+
+        teamToggleCheckButtons.forEach { btn ->
+            // 토글 상태 변경에 따른 제어
+            btn.binding.toggleTeamToggleCheckButton.setOnCheckedChangeListener { buttonView, isChecked ->
+                btn.binding.cbTeamToggleCheckButton.isChecked = isChecked
+                if (isChecked) {
+                    selectedButton?.binding?.toggleTeamToggleCheckButton?.isChecked = false
+                    buttonView.isChecked = true
+                    selectedButton = btn
+                    binding.layoutFooterPlayTeamBottomSheet.btnFooterOne.isEnabled = true
+                } else {
+                    binding.layoutFooterPlayTeamBottomSheet.btnFooterOne.isEnabled = false
+                }
+            }
+
+            // 체크박스 상태 변경에 따른 제어
+            btn.binding.cbTeamToggleCheckButton.setOnCheckedChangeListener { buttonView, isChecked ->
+                btn.binding.toggleTeamToggleCheckButton.isChecked = isChecked
+                if (isChecked) {
+                    selectedButton?.binding?.cbTeamToggleCheckButton?.isChecked = false
+                    buttonView.isChecked = true
+                    selectedButton = btn
+                    binding.layoutFooterPlayTeamBottomSheet.btnFooterOne.isEnabled = true
+                } else {
+                    binding.layoutFooterPlayTeamBottomSheet.btnFooterOne.isEnabled = false
+                }
+            }
+
+            // 버튼 전체 클릭 시 체크 상태 반영되도록
+            btn.setOnClickListener {
+                btn.binding.toggleTeamToggleCheckButton.isChecked = !btn.binding.toggleTeamToggleCheckButton.isChecked
+            }
+        }
+    }
+}

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/PostPlayTeamBottomSheetFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/PostPlayTeamBottomSheetFragment.kt
@@ -5,18 +5,23 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.constraintlayout.widget.ConstraintLayout
 import com.catchmate.presentation.R
 import com.catchmate.presentation.databinding.FragmentPostPlayTeamBottomSheetBinding
+import com.catchmate.presentation.interaction.OnTeamSelectedListener
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
-class PostPlayTeamBottomSheetFragment : BottomSheetDialogFragment() {
+class PostPlayTeamBottomSheetFragment(
+    val firstTeam: String?,
+    val secondTeam: String?,
+) : BottomSheetDialogFragment() {
     private var _binding: FragmentPostPlayTeamBottomSheetBinding? = null
     val binding get() = _binding!!
 
+    var teamSelectedListener: OnTeamSelectedListener? = null
     var selectedButton: TeamToggleCheckButtonView? = null
+    lateinit var teamType: String
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val dialog = super.onCreateDialog(savedInstanceState) as BottomSheetDialog
@@ -35,9 +40,13 @@ class PostPlayTeamBottomSheetFragment : BottomSheetDialogFragment() {
         return binding.root
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
         super.onViewCreated(view, savedInstanceState)
         initTeamButtons()
+        initFooter()
     }
 
     override fun onDestroyView() {
@@ -87,10 +96,36 @@ class PostPlayTeamBottomSheetFragment : BottomSheetDialogFragment() {
                 }
             }
 
+            // 디폴트 버튼 설정
+            if (firstTeam != null && btn.binding.tvTeamToggleCheckButton.text == firstTeam) {
+                btn.binding.toggleTeamToggleCheckButton.isChecked = true
+            }
+
+            // 비활성화 버튼 설정
+            if (secondTeam != null && btn.binding.tvTeamToggleCheckButton.text == secondTeam) {
+                btn.isEnabled = false
+                btn.binding.tvTeamToggleCheckButton.isEnabled = false
+            }
+
             // 버튼 전체 클릭 시 체크 상태 반영되도록
             btn.setOnClickListener {
                 btn.binding.toggleTeamToggleCheckButton.isChecked = !btn.binding.toggleTeamToggleCheckButton.isChecked
             }
         }
+    }
+
+    private fun initFooter() {
+        binding.layoutFooterPlayTeamBottomSheet.btnFooterOne.apply {
+            text = getString(R.string.complete)
+            setOnClickListener {
+                teamSelectedListener?.onTeamSelected(selectedButton?.binding?.tvTeamToggleCheckButton?.text.toString(), teamType)
+                dismiss()
+            }
+        }
+    }
+
+    fun setOnTeamSelectedListener(listener: OnTeamSelectedListener, teamType: String) {
+        teamSelectedListener = listener
+        this.teamType = teamType
     }
 }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/TeamToggleCheckButtonView.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/TeamToggleCheckButtonView.kt
@@ -44,18 +44,11 @@ class TeamToggleCheckButtonView(
         val teamLogo = typedArray.getResourceId(R.styleable.TeamToggleCheckButtonView_teamToggleCheckButtonLogoImage, 0)
         val teamName = typedArray.getText(R.styleable.TeamToggleCheckButtonView_teamToggleCheckButtonTeamNameText)
 
-
-        if (toggleBg != 0) {
-            binding.toggleTeamToggleCheckButton.setBackgroundResource(toggleBg)
-        }
-
-        if (teamLogo != 0) {
-            binding.ivTeamToggleCheckButton.setImageResource(teamLogo)
-        }
+        if (toggleBg != 0) binding.toggleTeamToggleCheckButton.setBackgroundResource(toggleBg)
+        if (teamLogo != 0) binding.ivTeamToggleCheckButton.setImageResource(teamLogo)
 
         binding.tvTeamToggleCheckButton.text = teamName
-
-
+        
         typedArray.recycle()
     }
 }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/TeamToggleCheckButtonView.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/TeamToggleCheckButtonView.kt
@@ -1,0 +1,61 @@
+package com.catchmate.presentation.view.post
+
+import android.content.Context
+import android.content.res.TypedArray
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import androidx.constraintlayout.widget.ConstraintLayout
+import com.catchmate.presentation.R
+import com.catchmate.presentation.databinding.ViewTeamToggleCheckButtonBinding
+
+class TeamToggleCheckButtonView(
+    context: Context,
+    attrs: AttributeSet,
+) : ConstraintLayout(context, attrs) {
+    val binding: ViewTeamToggleCheckButtonBinding by lazy {
+        ViewTeamToggleCheckButtonBinding.inflate(
+            LayoutInflater.from(context),
+            this,
+            true,
+        )
+    }
+
+    init {
+        initView()
+        getAttrs(attrs)
+    }
+
+    private fun initView() {
+        binding.toggleTeamToggleCheckButton.setOnCheckedChangeListener { _, isChecked ->
+            binding.cbTeamToggleCheckButton.isChecked = isChecked
+        }
+        binding.cbTeamToggleCheckButton.setOnCheckedChangeListener { _, isChecked ->
+            binding.toggleTeamToggleCheckButton.isChecked = isChecked
+        }
+    }
+
+    private fun getAttrs(attrs: AttributeSet) {
+        val typedArray = context.obtainStyledAttributes(attrs, R.styleable.TeamToggleCheckButtonView)
+        setTypeArray(typedArray)
+    }
+
+    private fun setTypeArray(typedArray: TypedArray) {
+        val toggleBg = typedArray.getResourceId(R.styleable.TeamToggleCheckButtonView_teamToggleCheckButtonToggleBg, 0)
+        val teamLogo = typedArray.getResourceId(R.styleable.TeamToggleCheckButtonView_teamToggleCheckButtonLogoImage, 0)
+        val teamName = typedArray.getText(R.styleable.TeamToggleCheckButtonView_teamToggleCheckButtonTeamNameText)
+
+
+        if (toggleBg != 0) {
+            binding.toggleTeamToggleCheckButton.setBackgroundResource(toggleBg)
+        }
+
+        if (teamLogo != 0) {
+            binding.ivTeamToggleCheckButton.setImageResource(teamLogo)
+        }
+
+        binding.tvTeamToggleCheckButton.text = teamName
+
+
+        typedArray.recycle()
+    }
+}

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/TeamToggleCheckButtonView.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/TeamToggleCheckButtonView.kt
@@ -48,7 +48,7 @@ class TeamToggleCheckButtonView(
         if (teamLogo != 0) binding.ivTeamToggleCheckButton.setImageResource(teamLogo)
 
         binding.tvTeamToggleCheckButton.text = teamName
-        
+
         typedArray.recycle()
     }
 }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/viewmodel/AddPostViewModel.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/viewmodel/AddPostViewModel.kt
@@ -1,0 +1,56 @@
+package com.catchmate.presentation.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.catchmate.domain.model.BoardWriteRequest
+import com.catchmate.domain.model.BoardWriteResponse
+import com.catchmate.domain.usecase.BoardWriteUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class AddPostViewModel
+    @Inject
+    constructor(
+        private val boardWriteUseCase: BoardWriteUseCase,
+    ) : ViewModel() {
+        private var _homeTeamName = MutableLiveData<String>()
+        val homeTeamName: LiveData<String>
+            get() = _homeTeamName
+
+        private var _awayTeamName = MutableLiveData<String>()
+        val awayTeamName: LiveData<String>
+            get() = _awayTeamName
+
+        private var _gameDateTime = MutableLiveData<String>()
+        val gameDateTime: LiveData<String>
+            get() = _gameDateTime
+
+        private var _boardWriteResponse = MutableLiveData<BoardWriteResponse>()
+        val boardWriteResponse: LiveData<BoardWriteResponse>
+            get() = _boardWriteResponse
+
+        fun setHomeTeamName(teamName: String) {
+            _homeTeamName.value = teamName
+        }
+
+        fun setAwayTeamName(teamName: String) {
+            _awayTeamName.value = teamName
+        }
+
+        fun setGameDate(gameDateTime: String) {
+            _gameDateTime.value = gameDateTime
+        }
+
+        fun postBoardWrite(
+            accessToken: String,
+            boardWriteRequest: BoardWriteRequest,
+        ) {
+            viewModelScope.launch {
+                _boardWriteResponse.value = boardWriteUseCase.postBoardWrite(accessToken, boardWriteRequest)
+            }
+        }
+    }

--- a/CatchMate/presentation/src/main/res/color/color_team_toggle_check_button_text.xml
+++ b/CatchMate/presentation/src/main/res/color/color_team_toggle_check_button_text.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/grey800" android:state_enabled="true"/>
+    <item android:color="@color/grey300" android:state_enabled="false"/>
+</selector>

--- a/CatchMate/presentation/src/main/res/drawable/shape_all_bottom_sheet_bg.xml
+++ b/CatchMate/presentation/src/main/res/drawable/shape_all_bottom_sheet_bg.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners
+        android:topLeftRadius="16dp"
+        android:topRightRadius="16dp"/>
+    <solid
+        android:color="@color/grey0"/>
+</shape>

--- a/CatchMate/presentation/src/main/res/layout/fragment_add_post.xml
+++ b/CatchMate/presentation/src/main/res/layout/fragment_add_post.xml
@@ -84,15 +84,14 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/tv_add_post_title_basic_info" />
 
-            <EditText
-                android:id="@+id/edt_add_post_people_count"
+            <TextView
+                android:id="@+id/tv_add_post_people_count"
                 android:layout_width="0dp"
                 android:layout_height="@dimen/layout_height"
                 android:layout_marginTop="@dimen/tiny"
                 android:background="@drawable/selector_all_edt_bg"
-                android:ems="10"
+                android:gravity="center_vertical"
                 android:hint="@string/post_edt_hint_count"
-                android:inputType="number"
                 android:paddingLeft="@dimen/small"
                 android:paddingRight="@dimen/small"
                 android:textAppearance="@style/Typography.Body02.Medium"
@@ -110,9 +109,9 @@
                 android:text="@string/post_edt_hint_count_unit"
                 android:textAppearance="@style/Typography.Body02.SemiBold"
                 android:textColor="@color/grey400"
-                app:layout_constraintBottom_toBottomOf="@+id/edt_add_post_people_count"
-                app:layout_constraintEnd_toEndOf="@+id/edt_add_post_people_count"
-                app:layout_constraintTop_toTopOf="@+id/edt_add_post_people_count" />
+                app:layout_constraintBottom_toBottomOf="@+id/tv_add_post_people_count"
+                app:layout_constraintEnd_toEndOf="@+id/tv_add_post_people_count"
+                app:layout_constraintTop_toTopOf="@+id/tv_add_post_people_count" />
 
             <TextView
                 android:id="@+id/tv_add_post_game_info"
@@ -123,7 +122,7 @@
                 android:textAppearance="@style/Typography.Body02.Medium"
                 android:textColor="@color/grey500"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/edt_add_post_people_count" />
+                app:layout_constraintTop_toBottomOf="@+id/tv_add_post_people_count" />
 
             <ImageView
                 android:id="@+id/iv_add_post_essential_mark_game_info"
@@ -135,15 +134,14 @@
                 app:layout_constraintStart_toEndOf="@+id/tv_add_post_game_info"
                 app:layout_constraintTop_toTopOf="@+id/tv_add_post_game_info" />
 
-            <EditText
-                android:id="@+id/edt_add_post_game_date_time"
+            <TextView
+                android:id="@+id/tv_add_post_game_date_time"
                 android:layout_width="0dp"
                 android:layout_height="@dimen/layout_height"
                 android:layout_marginTop="16dp"
                 android:background="@drawable/shape_all_rect_r8_grey50"
-                android:ems="10"
+                android:gravity="center_vertical"
                 android:hint="@string/post_edt_hint_game_date_time"
-                android:inputType="text"
                 android:paddingLeft="@dimen/small"
                 android:paddingRight="@dimen/small"
                 android:textAppearance="@style/Typography.Body02.Medium"
@@ -153,53 +151,50 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/tv_add_post_game_info" />
 
-            <EditText
-                android:id="@+id/edt_add_post_home_team"
+            <TextView
+                android:id="@+id/tv_add_post_home_team"
                 android:layout_width="0dp"
                 android:layout_height="@dimen/layout_height"
                 android:layout_marginTop="@dimen/tiny"
                 android:layout_marginRight="@dimen/gutter"
                 android:background="@drawable/shape_all_rect_r8_grey50"
-                android:ems="10"
+                android:gravity="center_vertical"
                 android:hint="@string/post_edt_hint_home"
-                android:inputType="text"
                 android:paddingLeft="@dimen/small"
                 android:paddingRight="@dimen/small"
                 android:textAppearance="@style/Typography.Body02.Medium"
                 android:textColor="@color/grey800"
                 android:textColorHint="@color/grey400"
-                app:layout_constraintEnd_toStartOf="@+id/edt_add_post_away_team"
+                app:layout_constraintEnd_toStartOf="@+id/tv_add_post_away_team"
                 app:layout_constraintHorizontal_chainStyle="spread_inside"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/edt_add_post_game_date_time" />
+                app:layout_constraintTop_toBottomOf="@+id/tv_add_post_game_date_time" />
 
-            <EditText
-                android:id="@+id/edt_add_post_away_team"
+            <TextView
+                android:id="@+id/tv_add_post_away_team"
                 android:layout_width="0dp"
                 android:layout_height="@dimen/layout_height"
                 android:layout_marginTop="@dimen/tiny"
                 android:background="@drawable/shape_all_rect_r8_grey50"
-                android:ems="10"
+                android:gravity="center_vertical"
                 android:hint="@string/post_edt_hint_away"
-                android:inputType="text"
                 android:paddingLeft="@dimen/small"
                 android:paddingRight="@dimen/small"
                 android:textAppearance="@style/Typography.Body02.Medium"
                 android:textColor="@color/grey800"
                 android:textColorHint="@color/grey400"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@+id/edt_add_post_home_team"
-                app:layout_constraintTop_toBottomOf="@+id/edt_add_post_game_date_time" />
+                app:layout_constraintStart_toEndOf="@+id/tv_add_post_home_team"
+                app:layout_constraintTop_toBottomOf="@+id/tv_add_post_game_date_time" />
 
-            <EditText
-                android:id="@+id/editTextText"
+            <TextView
+                android:id="@+id/tv_add_post_cheer_team"
                 android:layout_width="0dp"
                 android:layout_height="@dimen/layout_height"
                 android:layout_marginTop="@dimen/tiny"
                 android:background="@drawable/shape_all_rect_r8_grey50"
-                android:ems="10"
+                android:gravity="center_vertical"
                 android:hint="@string/post_edt_hint_cheer_team"
-                android:inputType="text"
                 android:paddingLeft="@dimen/small"
                 android:paddingRight="@dimen/small"
                 android:textAppearance="@style/Typography.Body02.Medium"
@@ -207,17 +202,16 @@
                 android:textColorHint="@color/grey400"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/edt_add_post_home_team" />
+                app:layout_constraintTop_toBottomOf="@+id/tv_add_post_home_team" />
 
-            <EditText
-                android:id="@+id/edt_add_post_place"
+            <TextView
+                android:id="@+id/tv_add_post_place"
                 android:layout_width="0dp"
                 android:layout_height="@dimen/layout_height"
                 android:layout_marginTop="@dimen/tiny"
                 android:background="@drawable/shape_all_rect_r8_grey50"
-                android:ems="10"
+                android:gravity="center_vertical"
                 android:hint="@string/post_edt_hint_place"
-                android:inputType="text"
                 android:paddingLeft="@dimen/small"
                 android:paddingRight="@dimen/small"
                 android:textAppearance="@style/Typography.Body02.Medium"
@@ -225,7 +219,7 @@
                 android:textColorHint="@color/grey400"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/editTextText" />
+                app:layout_constraintTop_toBottomOf="@+id/tv_add_post_cheer_team" />
 
             <TextView
                 android:id="@+id/tv_add_post_additional_info"
@@ -236,7 +230,7 @@
                 android:textAppearance="@style/Typography.Body02.Medium"
                 android:textColor="@color/grey500"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/edt_add_post_place" />
+                app:layout_constraintTop_toBottomOf="@+id/tv_add_post_place" />
 
             <ImageView
                 android:id="@+id/iv_add_post_essential_mark_additional_info"
@@ -252,12 +246,12 @@
                 android:id="@+id/tv_add_post_additional_info_letter_count"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:text="0"
                 android:textAppearance="@style/Typography.Body02.Medium"
                 android:textColor="@color/grey500"
                 app:layout_constraintBottom_toBottomOf="@+id/tv_add_post_additional_info_letter_count_limit"
                 app:layout_constraintEnd_toStartOf="@+id/tv_add_post_additional_info_letter_count_limit"
-                app:layout_constraintTop_toTopOf="@+id/tv_add_post_additional_info_letter_count_limit"
-                tools:text="0" />
+                app:layout_constraintTop_toTopOf="@+id/tv_add_post_additional_info_letter_count_limit" />
 
             <TextView
                 android:id="@+id/tv_add_post_additional_info_letter_count_limit"
@@ -328,21 +322,21 @@
 
                 <com.google.android.material.chip.Chip
                     android:id="@+id/chip_add_post_gender_regardless"
-                    style="@style/CustomePostGenderChip"
+                    style="@style/CustomPostGenderChip"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/regardless_of_gender" />
 
                 <com.google.android.material.chip.Chip
                     android:id="@+id/chip_add_post_gender_female"
-                    style="@style/CustomePostGenderChip"
+                    style="@style/CustomPostGenderChip"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/female" />
 
                 <com.google.android.material.chip.Chip
                     android:id="@+id/chip_add_post_gender_male"
-                    style="@style/CustomePostGenderChip"
+                    style="@style/CustomPostGenderChip"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/male" />
@@ -372,42 +366,42 @@
 
                 <com.google.android.material.chip.Chip
                     android:id="@+id/chip_add_post_age_regardless"
-                    style="@style/CustomePostGenderChip"
+                    style="@style/CustomPostGenderChip"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/regardless_of_age" />
 
                 <com.google.android.material.chip.Chip
                     android:id="@+id/chip_add_post_age_teenager"
-                    style="@style/CustomePostGenderChip"
+                    style="@style/CustomPostGenderChip"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/teenager" />
 
                 <com.google.android.material.chip.Chip
                     android:id="@+id/chip_add_post_age_twenties"
-                    style="@style/CustomePostGenderChip"
+                    style="@style/CustomPostGenderChip"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/twenties" />
 
                 <com.google.android.material.chip.Chip
                     android:id="@+id/chip_add_post_age_thirties"
-                    style="@style/CustomePostGenderChip"
+                    style="@style/CustomPostGenderChip"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/thirties" />
 
                 <com.google.android.material.chip.Chip
                     android:id="@+id/chip_add_post_age_fourties"
-                    style="@style/CustomePostGenderChip"
+                    style="@style/CustomPostGenderChip"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/fourties" />
 
                 <com.google.android.material.chip.Chip
                     android:id="@+id/chip_add_post_age_fifties"
-                    style="@style/CustomePostGenderChip"
+                    style="@style/CustomPostGenderChip"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/fifties" />

--- a/CatchMate/presentation/src/main/res/layout/fragment_home_team_filter_bottom_sheet.xml
+++ b/CatchMate/presentation/src/main/res/layout/fragment_home_team_filter_bottom_sheet.xml
@@ -26,384 +26,123 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/draghandleview_teambottomsheet">
 
-        <LinearLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:paddingLeft="@dimen/base"
+            android:paddingRight="@dimen/base"
+            android:paddingBottom="36dp">
 
-            <LinearLayout
-                android:id="@+id/layout_nc"
+            <com.catchmate.presentation.view.post.TeamToggleCheckButtonView
+                android:id="@+id/ttcbv_team_filter_nc"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/small"
-                android:layout_marginTop="12dp"
-                android:layout_marginEnd="@dimen/small"
-                android:gravity="center_vertical"
-                android:orientation="horizontal"
-                android:paddingLeft="8dp"
-                android:paddingTop="11dp"
-                android:paddingRight="8dp"
-                android:paddingBottom="11dp">
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:teamToggleCheckButtonLogoImage="@drawable/vec_all_essential_mark_6dp"
+                app:teamToggleCheckButtonTeamNameText="@string/team_nc_dinos"
+                app:teamToggleCheckButtonToggleBg="@drawable/selector_nc_dinos_bg" />
 
-                <ToggleButton
-                    android:id="@+id/toggle_nc"
-                    android:layout_width="50dp"
-                    android:layout_height="50dp"
-                    android:background="@drawable/selector_nc_dinos_bg"
-                    android:textOff="@null"
-                    android:textOn="@null" />
-
-                <TextView
-                    android:id="@+id/tv_nc"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginLeft="@dimen/small"
-                    android:layout_weight="1"
-                    android:text="@string/team_nc_dinos"
-                    android:textAppearance="@style/Typography.Body01.Medium" />
-
-                <CheckBox
-                    android:id="@+id/cb_nc"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:button="@drawable/selector_all_check_btn" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:id="@+id/layout_samsung"
+            <com.catchmate.presentation.view.post.TeamToggleCheckButtonView
+                android:id="@+id/ttcbv_team_filter_samsung"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/small"
-                android:layout_marginEnd="@dimen/small"
-                android:gravity="center_vertical"
-                android:orientation="horizontal"
-                android:paddingLeft="8dp"
-                android:paddingTop="11dp"
-                android:paddingRight="8dp"
-                android:paddingBottom="11dp">
+                android:layout_marginTop="22dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/ttcbv_team_filter_nc"
+                app:teamToggleCheckButtonTeamNameText="@string/team_samsung_lions"
+                app:teamToggleCheckButtonToggleBg="@drawable/selector_samsung_lions_bg" />
 
-                <ToggleButton
-                    android:id="@+id/toggle_samsung"
-                    android:layout_width="50dp"
-                    android:layout_height="50dp"
-                    android:background="@drawable/selector_samsung_lions_bg"
-                    android:textOff="@null"
-                    android:textOn="@null" />
-
-                <TextView
-                    android:id="@+id/tv_samsung"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginLeft="@dimen/small"
-                    android:layout_weight="1"
-                    android:text="@string/team_samsung_lions"
-                    android:textAppearance="@style/Typography.Body01.Medium" />
-
-                <CheckBox
-                    android:id="@+id/cb_samsung"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:button="@drawable/selector_all_check_btn" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:id="@+id/layout_ssg"
+            <com.catchmate.presentation.view.post.TeamToggleCheckButtonView
+                android:id="@+id/ttcbv_team_filter_ssg"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/small"
-                android:layout_marginEnd="@dimen/small"
-                android:gravity="center_vertical"
-                android:orientation="horizontal"
-                android:paddingLeft="8dp"
-                android:paddingTop="11dp"
-                android:paddingRight="8dp"
-                android:paddingBottom="11dp">
+                android:layout_marginTop="22dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/ttcbv_team_filter_samsung"
+                app:teamToggleCheckButtonTeamNameText="@string/team_ssg_landers"
+                app:teamToggleCheckButtonToggleBg="@drawable/selector_ssg_landers_bg" />
 
-                <ToggleButton
-                    android:id="@+id/toggle_ssg"
-                    android:layout_width="50dp"
-                    android:layout_height="50dp"
-                    android:background="@drawable/selector_ssg_landers_bg"
-                    android:textOff="@null"
-                    android:textOn="@null" />
-
-                <TextView
-                    android:id="@+id/tv_ssg"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginLeft="@dimen/small"
-                    android:layout_weight="1"
-                    android:text="@string/team_ssg_landers"
-                    android:textAppearance="@style/Typography.Body01.Medium" />
-
-                <CheckBox
-                    android:id="@+id/cb_ssg"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:button="@drawable/selector_all_check_btn" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:id="@+id/layout_doosan"
+            <com.catchmate.presentation.view.post.TeamToggleCheckButtonView
+                android:id="@+id/ttcbv_team_filter_doosan"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/small"
-                android:layout_marginEnd="@dimen/small"
-                android:gravity="center_vertical"
-                android:orientation="horizontal"
-                android:paddingLeft="8dp"
-                android:paddingTop="11dp"
-                android:paddingRight="8dp"
-                android:paddingBottom="11dp">
+                android:layout_marginTop="22dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/ttcbv_team_filter_ssg"
+                app:teamToggleCheckButtonTeamNameText="@string/team_doosan_bears"
+                app:teamToggleCheckButtonToggleBg="@drawable/selector_doosan_bears_bg" />
 
-                <ToggleButton
-                    android:id="@+id/toggle_doosan"
-                    android:layout_width="50dp"
-                    android:layout_height="50dp"
-                    android:background="@drawable/selector_doosan_bears_bg"
-                    android:textOff="@null"
-                    android:textOn="@null" />
-
-                <TextView
-                    android:id="@+id/tv_doosan"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginLeft="@dimen/small"
-                    android:layout_weight="1"
-                    android:text="@string/team_doosan_bears"
-                    android:textAppearance="@style/Typography.Body01.Medium" />
-
-                <CheckBox
-                    android:id="@+id/cb_doosan"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:button="@drawable/selector_all_check_btn" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:id="@+id/layout_kt"
+            <com.catchmate.presentation.view.post.TeamToggleCheckButtonView
+                android:id="@+id/ttcbv_team_filter_kt"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/small"
-                android:layout_marginEnd="@dimen/small"
-                android:gravity="center_vertical"
-                android:orientation="horizontal"
-                android:paddingLeft="8dp"
-                android:paddingTop="11dp"
-                android:paddingRight="8dp"
-                android:paddingBottom="11dp">
+                android:layout_marginTop="22dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/ttcbv_team_filter_doosan"
+                app:teamToggleCheckButtonTeamNameText="@string/team_kt_wiz"
+                app:teamToggleCheckButtonToggleBg="@drawable/selector_kt_wiz_bg" />
 
-                <ToggleButton
-                    android:id="@+id/toggle_kt"
-                    android:layout_width="50dp"
-                    android:layout_height="50dp"
-                    android:background="@drawable/selector_kt_wiz_bg"
-                    android:textOff="@null"
-                    android:textOn="@null" />
-
-                <TextView
-                    android:id="@+id/tv_kt"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginLeft="@dimen/small"
-                    android:layout_weight="1"
-                    android:text="@string/team_kt_wiz"
-                    android:textAppearance="@style/Typography.Body01.Medium" />
-
-                <CheckBox
-                    android:id="@+id/cb_kt"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:button="@drawable/selector_all_check_btn" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:id="@+id/layout_hanwha"
+            <com.catchmate.presentation.view.post.TeamToggleCheckButtonView
+                android:id="@+id/ttcbv_team_filter_hanwha"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/small"
-                android:layout_marginEnd="@dimen/small"
-                android:gravity="center_vertical"
-                android:orientation="horizontal"
-                android:paddingLeft="8dp"
-                android:paddingTop="11dp"
-                android:paddingRight="8dp"
-                android:paddingBottom="11dp">
+                android:layout_marginTop="22dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/ttcbv_team_filter_kt"
+                app:teamToggleCheckButtonTeamNameText="@string/team_hanwha_eagles"
+                app:teamToggleCheckButtonToggleBg="@drawable/selector_hanwha_eagles_bg" />
 
-                <ToggleButton
-                    android:id="@+id/toggle_hanwha"
-                    android:layout_width="50dp"
-                    android:layout_height="50dp"
-                    android:background="@drawable/selector_hanwha_eagles_bg"
-                    android:textOff="@null"
-                    android:textOn="@null" />
-
-                <TextView
-                    android:id="@+id/tv_hanwha"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginLeft="@dimen/small"
-                    android:layout_weight="1"
-                    android:text="@string/team_hanwha_eagles"
-                    android:textAppearance="@style/Typography.Body01.Medium" />
-
-                <CheckBox
-                    android:id="@+id/cb_hanwha"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:button="@drawable/selector_all_check_btn" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:id="@+id/layout_lotte"
+            <com.catchmate.presentation.view.post.TeamToggleCheckButtonView
+                android:id="@+id/ttcbv_team_filter_lotte"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/small"
-                android:layout_marginEnd="@dimen/small"
-                android:gravity="center_vertical"
-                android:orientation="horizontal"
-                android:paddingLeft="8dp"
-                android:paddingTop="11dp"
-                android:paddingRight="8dp"
-                android:paddingBottom="11dp">
+                android:layout_marginTop="22dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/ttcbv_team_filter_hanwha"
+                app:teamToggleCheckButtonTeamNameText="@string/team_lotte_giants"
+                app:teamToggleCheckButtonToggleBg="@drawable/selector_lotte_giants_bg" />
 
-                <ToggleButton
-                    android:id="@+id/toggle_lotte"
-                    android:layout_width="50dp"
-                    android:layout_height="50dp"
-                    android:background="@drawable/selector_lotte_giants_bg"
-                    android:textOff="@null"
-                    android:textOn="@null" />
-
-                <TextView
-                    android:id="@+id/tv_lotte"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginLeft="@dimen/small"
-                    android:layout_weight="1"
-                    android:text="@string/team_lotte_giants"
-                    android:textAppearance="@style/Typography.Body01.Medium" />
-
-                <CheckBox
-                    android:id="@+id/cb_lotte"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:button="@drawable/selector_all_check_btn" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:id="@+id/layout_kia"
+            <com.catchmate.presentation.view.post.TeamToggleCheckButtonView
+                android:id="@+id/ttcbv_team_filter_kia"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/small"
-                android:layout_marginEnd="@dimen/small"
-                android:gravity="center_vertical"
-                android:orientation="horizontal"
-                android:paddingLeft="8dp"
-                android:paddingTop="11dp"
-                android:paddingRight="8dp"
-                android:paddingBottom="11dp">
+                android:layout_marginTop="22dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/ttcbv_team_filter_lotte"
+                app:teamToggleCheckButtonTeamNameText="@string/team_kia_tigers"
+                app:teamToggleCheckButtonToggleBg="@drawable/selector_kia_tigers_bg" />
 
-                <ToggleButton
-                    android:id="@+id/toggle_kia"
-                    android:layout_width="50dp"
-                    android:layout_height="50dp"
-                    android:background="@drawable/selector_kia_tigers_bg"
-                    android:textOff="@null"
-                    android:textOn="@null" />
-
-                <TextView
-                    android:id="@+id/tv_kia"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginLeft="@dimen/small"
-                    android:layout_weight="1"
-                    android:text="@string/team_kia_tigers"
-                    android:textAppearance="@style/Typography.Body01.Medium" />
-
-                <CheckBox
-                    android:id="@+id/cb_kia"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:button="@drawable/selector_all_check_btn" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:id="@+id/layout_lg"
+            <com.catchmate.presentation.view.post.TeamToggleCheckButtonView
+                android:id="@+id/ttcbv_team_filter_lg"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/small"
-                android:layout_marginEnd="@dimen/small"
-                android:gravity="center_vertical"
-                android:orientation="horizontal"
-                android:paddingLeft="8dp"
-                android:paddingTop="11dp"
-                android:paddingRight="8dp"
-                android:paddingBottom="11dp">
+                android:layout_marginTop="22dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/ttcbv_team_filter_kia"
+                app:teamToggleCheckButtonTeamNameText="@string/team_lg_twins"
+                app:teamToggleCheckButtonToggleBg="@drawable/selector_lg_twins_bg" />
 
-                <ToggleButton
-                    android:id="@+id/toggle_lg"
-                    android:layout_width="50dp"
-                    android:layout_height="50dp"
-                    android:background="@drawable/selector_lg_twins_bg"
-                    android:textOff="@null"
-                    android:textOn="@null" />
-
-                <TextView
-                    android:id="@+id/tv_lg"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginLeft="@dimen/small"
-                    android:layout_weight="1"
-                    android:text="@string/team_lg_twins"
-                    android:textAppearance="@style/Typography.Body01.Medium" />
-
-                <CheckBox
-                    android:id="@+id/cb_lg"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:button="@drawable/selector_all_check_btn" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:id="@+id/layout_kiwoom"
+            <com.catchmate.presentation.view.post.TeamToggleCheckButtonView
+                android:id="@+id/ttcbv_team_filter_kiwoom"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/small"
-                android:layout_marginEnd="@dimen/small"
-                android:layout_marginBottom="2dp"
-                android:gravity="center_vertical"
-                android:orientation="horizontal"
-                android:paddingLeft="8dp"
-                android:paddingTop="11dp"
-                android:paddingRight="8dp"
-                android:paddingBottom="11dp">
-
-                <ToggleButton
-                    android:id="@+id/toggle_kiwoom"
-                    android:layout_width="50dp"
-                    android:layout_height="50dp"
-                    android:background="@drawable/selector_kiwoom_heroes_bg"
-                    android:textOff="@null"
-                    android:textOn="@null" />
-
-                <TextView
-                    android:id="@+id/tv_kiwoom"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginLeft="@dimen/small"
-                    android:layout_weight="1"
-                    android:text="@string/team_kiwoom_heroes"
-                    android:textAppearance="@style/Typography.Body01.Medium" />
-
-                <CheckBox
-                    android:id="@+id/cb_kiwoom"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:button="@drawable/selector_all_check_btn" />
-            </LinearLayout>
-
-        </LinearLayout>
+                android:layout_marginTop="22dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/ttcbv_team_filter_lg"
+                app:teamToggleCheckButtonTeamNameText="@string/team_kiwoom_heroes"
+                app:teamToggleCheckButtonToggleBg="@drawable/selector_kiwoom_heroes_bg" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.core.widget.NestedScrollView>
 
     <include

--- a/CatchMate/presentation/src/main/res/layout/fragment_post_cheer_team_bottom_sheet.xml
+++ b/CatchMate/presentation/src/main/res/layout/fragment_post_cheer_team_bottom_sheet.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/shape_all_bottom_sheet_bg"
+    tools:context=".view.post.PostCheerTeamBottomSheetFragment">
+
+    <com.google.android.material.bottomsheet.BottomSheetDragHandleView
+        android:id="@+id/draghandle_post_cheer_team"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/tiny"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/vec_all_bottom_sheet_handle_62dp" />
+
+    <com.catchmate.presentation.view.post.TeamToggleCheckButtonView
+        android:id="@+id/ttcbv_post_cheer_team_home"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/base"
+        android:layout_marginTop="@dimen/base"
+        android:layout_marginRight="@dimen/base"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/draghandle_post_cheer_team" />
+
+    <com.catchmate.presentation.view.post.TeamToggleCheckButtonView
+        android:id="@+id/ttcbv_post_cheer_team_away"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/base"
+        android:layout_marginTop="22dp"
+        android:layout_marginRight="@dimen/base"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/ttcbv_post_cheer_team_home" />
+
+    <include
+        android:id="@+id/layout_footer_post_cheer_team"
+        layout="@layout/layout_footer_one_button"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="36dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/ttcbv_post_cheer_team_away" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/CatchMate/presentation/src/main/res/layout/fragment_post_date_time_bottom_sheet.xml
+++ b/CatchMate/presentation/src/main/res/layout/fragment_post_date_time_bottom_sheet.xml
@@ -4,11 +4,12 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="@drawable/shape_all_bottom_sheet_bg"
     tools:context=".view.post.PostDateTimeBottomSheetFragment">
 
     <ImageView
         android:id="@+id/iv_post_date_time_handle"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/tiny"
         android:src="@drawable/vec_all_bottom_sheet_handle_62dp"
@@ -38,42 +39,57 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/cv_post_date_time" />
 
-    <com.google.android.material.chip.ChipGroup
-        android:id="@+id/cg_post_date_time"
-        android:layout_width="0dp"
+    <HorizontalScrollView
+        android:id="@+id/hsv_post_date_time"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/base"
         android:layout_marginTop="@dimen/xsmall"
         android:layout_marginEnd="@dimen/base"
+        android:scrollbarSize="0dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/tv_post_date_time_game_time_title"
-        app:singleLine="true"
-        app:singleSelection="true">
+        app:layout_constraintTop_toBottomOf="@+id/tv_post_date_time_game_time_title">
 
-        <com.google.android.material.chip.Chip
-            android:id="@+id/chip_post_date_time_2pm"
-            style="@style/CustomePostGenderChip"
-            android:layout_width="wrap_content"
+        <com.google.android.material.chip.ChipGroup
+            android:id="@+id/cg_post_date_time"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/post_game_time_2pm" />
+            app:singleLine="true"
+            app:singleSelection="true">
 
-        <com.google.android.material.chip.Chip
-            android:id="@+id/chip_post_date_time_5pm"
-            style="@style/CustomePostGenderChip"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/post_game_time_5pm" />
+            <com.google.android.material.chip.Chip
+                android:id="@+id/chip_post_date_time_2pm"
+                style="@style/CustomPostGenderChip"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/post_game_time_2pm" />
 
-        <com.google.android.material.chip.Chip
-            android:id="@+id/chip_post_date_time_6pm"
-            style="@style/CustomePostGenderChip"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/post_game_time_6pm" />
-    </com.google.android.material.chip.ChipGroup>
+            <com.google.android.material.chip.Chip
+                android:id="@+id/chip_post_date_time_5pm"
+                style="@style/CustomPostGenderChip"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/post_game_time_5pm" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/chip_post_date_time_6pm"
+                style="@style/CustomPostGenderChip"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/post_game_time_6pm" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/chip_post_date_time_6pm_30"
+                style="@style/CustomPostGenderChip"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/post_game_time_6pm_30" />
+        </com.google.android.material.chip.ChipGroup>
+    </HorizontalScrollView>
 
     <include
+        android:id="@+id/layout_footer_post_date_time"
         layout="@layout/layout_footer_one_button"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -81,5 +97,5 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/cg_post_date_time" />
+        app:layout_constraintTop_toBottomOf="@+id/hsv_post_date_time" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/CatchMate/presentation/src/main/res/layout/fragment_post_head_count_bottom_sheet.xml
+++ b/CatchMate/presentation/src/main/res/layout/fragment_post_head_count_bottom_sheet.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    tools:context=".view.post.PostHeadCountBottomSheetFragment" >
+    android:background="@drawable/shape_all_bottom_sheet_bg"
+    tools:context=".view.post.PostHeadCountBottomSheetFragment">
 
     <ImageView
         android:id="@+id/iv_post_head_count_handle"

--- a/CatchMate/presentation/src/main/res/layout/fragment_post_place_bottom_sheet.xml
+++ b/CatchMate/presentation/src/main/res/layout/fragment_post_place_bottom_sheet.xml
@@ -4,12 +4,12 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@color/grey0"
+    android:background="@drawable/shape_all_bottom_sheet_bg"
     tools:context=".view.post.PostPlaceBottomSheetFragment">
 
     <com.google.android.material.bottomsheet.BottomSheetDragHandleView
         android:id="@+id/view_post_place_handle"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/tiny"
         app:layout_constraintEnd_toEndOf="parent"

--- a/CatchMate/presentation/src/main/res/layout/fragment_post_play_team_bottom_sheet.xml
+++ b/CatchMate/presentation/src/main/res/layout/fragment_post_play_team_bottom_sheet.xml
@@ -5,7 +5,7 @@
     android:id="@+id/layout_post_play_team_bottom_sheet"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/grey0"
+    android:background="@drawable/shape_all_bottom_sheet_bg"
     android:minHeight="600dp"
     tools:context=".view.post.PostPlayTeamBottomSheetFragment">
 

--- a/CatchMate/presentation/src/main/res/layout/fragment_post_play_team_bottom_sheet.xml
+++ b/CatchMate/presentation/src/main/res/layout/fragment_post_play_team_bottom_sheet.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/layout_post_play_team_bottom_sheet"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/grey0"
+    android:minHeight="600dp"
+    tools:context=".view.post.PostPlayTeamBottomSheetFragment">
+
+    <com.google.android.material.bottomsheet.BottomSheetDragHandleView
+        android:id="@+id/draghandle_play_team_bottom_sheet"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/tiny"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/vec_all_bottom_sheet_handle_62dp" />
+
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/sv_play_team_bottom_sheet"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="@dimen/base"
+        android:fillViewport="true"
+        app:layout_constraintBottom_toTopOf="@+id/layout_footer_play_team_bottom_sheet"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/draghandle_play_team_bottom_sheet">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingLeft="@dimen/base"
+            android:paddingRight="@dimen/base"
+            android:paddingBottom="36dp">
+
+            <com.catchmate.presentation.view.post.TeamToggleCheckButtonView
+                android:id="@+id/ttcbv_play_team_bottom_sheet_nc"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:teamToggleCheckButtonLogoImage="@drawable/vec_all_essential_mark_6dp"
+                app:teamToggleCheckButtonTeamNameText="@string/team_nc_dinos"
+                app:teamToggleCheckButtonToggleBg="@drawable/selector_nc_dinos_bg" />
+
+            <com.catchmate.presentation.view.post.TeamToggleCheckButtonView
+                android:id="@+id/ttcbv_play_team_bottom_sheet_samsung"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="22dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/ttcbv_play_team_bottom_sheet_nc"
+                app:teamToggleCheckButtonLogoImage="@drawable/vec_all_essential_mark_6dp"
+                app:teamToggleCheckButtonTeamNameText="@string/team_samsung_lions"
+                app:teamToggleCheckButtonToggleBg="@drawable/selector_samsung_lions_bg" />
+
+            <com.catchmate.presentation.view.post.TeamToggleCheckButtonView
+                android:id="@+id/ttcbv_play_team_bottom_sheet_ssg"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="22dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/ttcbv_play_team_bottom_sheet_samsung"
+                app:teamToggleCheckButtonLogoImage="@drawable/vec_all_essential_mark_6dp"
+                app:teamToggleCheckButtonTeamNameText="@string/team_ssg_landers"
+                app:teamToggleCheckButtonToggleBg="@drawable/selector_ssg_landers_bg" />
+
+            <com.catchmate.presentation.view.post.TeamToggleCheckButtonView
+                android:id="@+id/ttcbv_play_team_bottom_sheet_doosan"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="22dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/ttcbv_play_team_bottom_sheet_ssg"
+                app:teamToggleCheckButtonLogoImage="@drawable/vec_all_essential_mark_6dp"
+                app:teamToggleCheckButtonTeamNameText="@string/team_doosan_bears"
+                app:teamToggleCheckButtonToggleBg="@drawable/selector_doosan_bears_bg" />
+
+            <com.catchmate.presentation.view.post.TeamToggleCheckButtonView
+                android:id="@+id/ttcbv_play_team_bottom_sheet_kt"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="22dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/ttcbv_play_team_bottom_sheet_doosan"
+                app:teamToggleCheckButtonLogoImage="@drawable/vec_all_essential_mark_6dp"
+                app:teamToggleCheckButtonTeamNameText="@string/team_kt_wiz"
+                app:teamToggleCheckButtonToggleBg="@drawable/selector_kt_wiz_bg" />
+
+            <com.catchmate.presentation.view.post.TeamToggleCheckButtonView
+                android:id="@+id/ttcbv_play_team_bottom_sheet_hanwha"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="22dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/ttcbv_play_team_bottom_sheet_kt"
+                app:teamToggleCheckButtonLogoImage="@drawable/vec_all_essential_mark_6dp"
+                app:teamToggleCheckButtonTeamNameText="@string/team_hanwha_eagles"
+                app:teamToggleCheckButtonToggleBg="@drawable/selector_hanwha_eagles_bg" />
+
+            <com.catchmate.presentation.view.post.TeamToggleCheckButtonView
+                android:id="@+id/ttcbv_play_team_bottom_sheet_lotte"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="22dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/ttcbv_play_team_bottom_sheet_hanwha"
+                app:teamToggleCheckButtonLogoImage="@drawable/vec_all_essential_mark_6dp"
+                app:teamToggleCheckButtonTeamNameText="@string/team_lotte_giants"
+                app:teamToggleCheckButtonToggleBg="@drawable/selector_lotte_giants_bg" />
+
+            <com.catchmate.presentation.view.post.TeamToggleCheckButtonView
+                android:id="@+id/ttcbv_play_team_bottom_sheet_kia"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="22dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/ttcbv_play_team_bottom_sheet_lotte"
+                app:teamToggleCheckButtonLogoImage="@drawable/vec_all_essential_mark_6dp"
+                app:teamToggleCheckButtonTeamNameText="@string/team_kia_tigers"
+                app:teamToggleCheckButtonToggleBg="@drawable/selector_kia_tigers_bg" />
+
+            <com.catchmate.presentation.view.post.TeamToggleCheckButtonView
+                android:id="@+id/ttcbv_play_team_bottom_sheet_lg"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="22dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/ttcbv_play_team_bottom_sheet_kia"
+                app:teamToggleCheckButtonLogoImage="@drawable/vec_all_essential_mark_6dp"
+                app:teamToggleCheckButtonTeamNameText="@string/team_lg_twins"
+                app:teamToggleCheckButtonToggleBg="@drawable/selector_lg_twins_bg" />
+
+            <com.catchmate.presentation.view.post.TeamToggleCheckButtonView
+                android:id="@+id/ttcbv_play_team_bottom_sheet_kiwoom"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="22dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/ttcbv_play_team_bottom_sheet_lg"
+                app:teamToggleCheckButtonLogoImage="@drawable/vec_all_essential_mark_6dp"
+                app:teamToggleCheckButtonTeamNameText="@string/team_kiwoom_heroes"
+                app:teamToggleCheckButtonToggleBg="@drawable/selector_kiwoom_heroes_bg" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.core.widget.NestedScrollView>
+
+    <include
+        android:id="@+id/layout_footer_play_team_bottom_sheet"
+        layout="@layout/layout_footer_one_button"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/CatchMate/presentation/src/main/res/layout/fragment_read_post.xml
+++ b/CatchMate/presentation/src/main/res/layout/fragment_read_post.xml
@@ -330,35 +330,35 @@
 
         <com.google.android.material.chip.Chip
             android:id="@+id/chip_read_post_age_1"
-            style="@style/CustomePostGenderChip"
+            style="@style/CustomPostGenderChip"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:checkable="false"/>
 
         <com.google.android.material.chip.Chip
             android:id="@+id/chip_read_post_age_2"
-            style="@style/CustomePostGenderChip"
+            style="@style/CustomPostGenderChip"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:checkable="false"/>
 
         <com.google.android.material.chip.Chip
             android:id="@+id/chip_read_post_age_3"
-            style="@style/CustomePostGenderChip"
+            style="@style/CustomPostGenderChip"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:checkable="false"/>
 
         <com.google.android.material.chip.Chip
             android:id="@+id/chip_read_post_age_4"
-            style="@style/CustomePostGenderChip"
+            style="@style/CustomPostGenderChip"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:checkable="false"/>
 
         <com.google.android.material.chip.Chip
             android:id="@+id/chip_read_post_gender"
-            style="@style/CustomePostGenderChip"
+            style="@style/CustomPostGenderChip"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:checkable="false"/>

--- a/CatchMate/presentation/src/main/res/layout/layout_footer_one_button.xml
+++ b/CatchMate/presentation/src/main/res/layout/layout_footer_one_button.xml
@@ -5,9 +5,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <Button
+    <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_footer_one"
-        style="@style/Widget.Material3.Button"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="12dp"
@@ -15,6 +14,8 @@
         android:layout_marginBottom="38dp"
         android:background="@drawable/shape_all_submit_button"
         android:enabled="false"
+        android:gravity="center"
+        android:stateListAnimator="@null"
         android:textAppearance="@style/Typography.Body01.SemiBold"
         android:textColor="@color/grey0"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/CatchMate/presentation/src/main/res/layout/view_team_toggle_check_button.xml
+++ b/CatchMate/presentation/src/main/res/layout/view_team_toggle_check_button.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ToggleButton
+        android:id="@+id/toggle_team_toggle_check_button"
+        android:layout_width="50dp"
+        android:layout_height="50dp"
+        android:background="@drawable/selector_nc_dinos_bg"
+        android:stateListAnimator="@null"
+        android:textOff="@null"
+        android:textOn="@null"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/iv_team_toggle_check_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="@+id/toggle_team_toggle_check_button"
+        app:layout_constraintEnd_toEndOf="@+id/toggle_team_toggle_check_button"
+        app:layout_constraintStart_toStartOf="@+id/toggle_team_toggle_check_button"
+        app:layout_constraintTop_toTopOf="@+id/toggle_team_toggle_check_button" />
+
+    <TextView
+        android:id="@+id/tv_team_toggle_check_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/xsmall"
+        android:textAppearance="@style/Typography.Body01.Medium"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/toggle_team_toggle_check_button"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <CheckBox
+        android:id="@+id/cb_team_toggle_check_button"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:background="@drawable/selector_all_check_btn"
+        android:button="@null"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/CatchMate/presentation/src/main/res/layout/view_team_toggle_check_button.xml
+++ b/CatchMate/presentation/src/main/res/layout/view_team_toggle_check_button.xml
@@ -8,7 +8,7 @@
         android:id="@+id/toggle_team_toggle_check_button"
         android:layout_width="50dp"
         android:layout_height="50dp"
-        android:background="@drawable/selector_nc_dinos_bg"
+        android:background="@null"
         android:stateListAnimator="@null"
         android:textOff="@null"
         android:textOn="@null"
@@ -31,6 +31,7 @@
         android:layout_height="wrap_content"
         android:layout_marginLeft="@dimen/xsmall"
         android:textAppearance="@style/Typography.Body01.Medium"
+        android:textColor="@color/color_team_toggle_check_button_text"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toEndOf="@+id/toggle_team_toggle_check_button"
         app:layout_constraintTop_toTopOf="parent" />

--- a/CatchMate/presentation/src/main/res/navigation/nav_graph.xml
+++ b/CatchMate/presentation/src/main/res/navigation/nav_graph.xml
@@ -65,7 +65,14 @@
         android:id="@+id/addPostFragment"
         android:name="com.catchmate.presentation.view.post.AddPostFragment"
         android:label="fragment_add_post"
-        tools:layout="@layout/fragment_add_post" />
+        tools:layout="@layout/fragment_add_post" >
+        <action
+            android:id="@+id/action_addPostFragment_to_readPostFragment"
+            app:destination="@id/readPostFragment" />
+        <action
+            android:id="@+id/action_addPostFragment_to_homeFragment"
+            app:destination="@id/homeFragment" />
+    </fragment>
     <fragment
         android:id="@+id/readPostFragment"
         android:name="com.catchmate.presentation.view.post.ReadPostFragment"

--- a/CatchMate/presentation/src/main/res/values/attrs.xml
+++ b/CatchMate/presentation/src/main/res/values/attrs.xml
@@ -44,4 +44,10 @@
         <attr name="myPageUserProfileGenderBadgeText" format="string"/>
         <attr name="myPageUserProfileAgeBadgeText" format="string"/>
     </declare-styleable>
+
+    <declare-styleable name="TeamToggleCheckButtonView">
+        <attr name="teamToggleCheckButtonToggleBg" format="reference"/>
+        <attr name="teamToggleCheckButtonLogoImage" format="reference"/>
+        <attr name="teamToggleCheckButtonTeamNameText" format="string"/>
+    </declare-styleable>
 </resources>

--- a/CatchMate/presentation/src/main/res/values/strings-post.xml
+++ b/CatchMate/presentation/src/main/res/values/strings-post.xml
@@ -30,7 +30,8 @@
     <string name="post_game_time_title">경기 시간</string>
     <string name="post_game_time_2pm">14:00</string>
     <string name="post_game_time_5pm">17:00</string>
-    <string name="post_game_time_6pm">18:30</string>
+    <string name="post_game_time_6pm">18:00</string>
+    <string name="post_game_time_6pm_30">18:30</string>
 
     <string name="application_detail_dialog_hint">간단한 자기소개를 적어주세요</string>
     <string name="application_detail_dialog_write_title">직관 신청을 보낼까요?</string>

--- a/CatchMate/presentation/src/main/res/values/strings-post.xml
+++ b/CatchMate/presentation/src/main/res/values/strings-post.xml
@@ -33,6 +33,19 @@
     <string name="post_game_time_6pm">18:00</string>
     <string name="post_game_time_6pm_30">18:30</string>
 
+    <string name="post_place_nc">창원</string>
+    <string name="post_place_ssg">인천</string>
+    <string name="post_place_doosan_lg">잠실</string>
+    <string name="post_place_kt">수원</string>
+    <string name="post_place_kia">광주</string>
+    <string name="post_place_kiwoom">고척</string>
+    <string name="post_place_lotte_first">사직</string>
+    <string name="post_place_lotte_second">울산</string>
+    <string name="post_place_hanwha_first">대전</string>
+    <string name="post_place_hanwha_second">청주</string>
+    <string name="post_place_samsung_first">대구</string>
+    <string name="post_place_samsung_second">포항</string>
+
     <string name="application_detail_dialog_hint">간단한 자기소개를 적어주세요</string>
     <string name="application_detail_dialog_write_title">직관 신청을 보낼까요?</string>
     <string name="application_detail_dialog_read_title">직관 신청을 보냈어요</string>

--- a/CatchMate/presentation/src/main/res/values/styles.xml
+++ b/CatchMate/presentation/src/main/res/values/styles.xml
@@ -14,8 +14,11 @@
         <item name="rippleColor">@android:color/transparent</item>
     </style>
 
-    <style name="CustomePostGenderChip" parent="Widget.Material3.Chip.Suggestion">
-        <item name="android:layout_height">34dp</item>
+    <style name="CustomPostGenderChip" parent="Widget.Material3.Chip.Suggestion">
+        <item name="android:paddingTop">8dp</item>
+        <item name="android:paddingBottom">8dp</item>
+        <item name="android:paddingLeft">16dp</item>
+        <item name="android:paddingRight">16dp</item>
         <item name="checkedIconVisible">false</item>
         <item name="chipStrokeColor">@android:color/transparent</item>
         <item name="chipBackgroundColor">@color/color_post_gender_chip_bg</item>


### PR DESCRIPTION
## 관련 이슈
- Related #41 
<br>

## 작업 내용
- 게시글 등록 화면 입력 뷰 유효성 검사
- 인원, 날짜, 구단, 응원팀, 구장 선택 Bottom Sheet 연결 및 구현
- post board write api 연결
<br>

## 참고 사항
- 임시 저장 및 불러오기 기능은 추후 구현 예정
- 인원 선택 시트의 number picker와 날짜 선택 시트의 date picker는 추후 커스텀 필요
<br>
