### PR TITLE
feature: 토큰 관리 로직 및 userId 저장 로직 구현

### DIFF
--- a/CatchMate/data/build.gradle.kts
+++ b/CatchMate/data/build.gradle.kts
@@ -43,6 +43,9 @@ dependencies {
     implementation(libs.firebase.messaging)
 
     implementation(libs.retrofit)
+    implementation(platform(libs.okhttp.bom))
+    implementation(libs.okhttp)
+    implementation(libs.logging.interceptor)
 
     implementation(libs.androidx.security.crypto.ktx)
 }

--- a/CatchMate/data/src/main/java/com/catchmate/data/datasource/local/LocalStorageDataSource.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/datasource/local/LocalStorageDataSource.kt
@@ -44,13 +44,31 @@ class LocalStorageDataSource
             }
         }
 
+        fun saveUserId(userId: Long) {
+            with(sharedPreferences.edit()) {
+                putLong("userId", userId)
+                commit()
+            }
+        }
+
         fun getAccessToken(): String = sharedPreferences.getString("accessToken", "") ?: ""
 
         fun getRefreshToken(): String = sharedPreferences.getString("refreshToken", "") ?: ""
 
+        fun getUserId(): Long = sharedPreferences.getLong("userId", -1L)
+
         fun removeTokens() {
             with(sharedPreferences.edit()) {
-                clear().apply()
+                remove("accessToken")
+                remove("refreshToken")
+                apply()
+            }
+        }
+
+        fun removeUserId() {
+            with(sharedPreferences.edit()) {
+                remove("userId")
+                apply()
             }
         }
     }

--- a/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/AuthAuthenticator.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/AuthAuthenticator.kt
@@ -1,0 +1,47 @@
+package com.catchmate.data.datasource.remote
+
+import com.catchmate.data.datasource.local.LocalStorageDataSource
+import com.catchmate.domain.exception.ReissueFailureException
+import kotlinx.coroutines.runBlocking
+import okhttp3.Authenticator
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+import javax.inject.Inject
+
+class AuthAuthenticator
+    @Inject
+    constructor(
+        private val localStorageDataSource: LocalStorageDataSource,
+        private val authRetrofitClient: AuthRetrofitClient,
+    ) : Authenticator {
+        override fun authenticate(
+            route: Route?,
+            response: Response,
+        ): Request? {
+            val refreshToken =
+                runBlocking {
+                    localStorageDataSource.getRefreshToken()
+                }
+
+            val reissueResponse = runBlocking {
+                authRetrofitClient.retrofit.postReissue(refreshToken)
+            }
+
+            return if (reissueResponse.isSuccessful) {
+                val newAccessToken = reissueResponse.body()?.accessToken
+
+                if (newAccessToken != null) {
+                    localStorageDataSource.saveAccessToken(newAccessToken)
+                    response.request
+                        .newBuilder()
+                        .header("AccessToken", newAccessToken)
+                        .build()
+                } else {
+                    throw ReissueFailureException("Reissue Error - AccessToken is null")
+                }
+            } else {
+                throw ReissueFailureException("Reissue Error - Reissue Failure")
+            }
+        }
+    }

--- a/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/AuthAuthenticator.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/AuthAuthenticator.kt
@@ -24,9 +24,10 @@ class AuthAuthenticator
                     localStorageDataSource.getRefreshToken()
                 }
 
-            val reissueResponse = runBlocking {
-                authRetrofitClient.retrofit.postReissue(refreshToken)
-            }
+            val reissueResponse =
+                runBlocking {
+                    authRetrofitClient.retrofit.postReissue(refreshToken)
+                }
 
             return if (reissueResponse.isSuccessful) {
                 val newAccessToken = reissueResponse.body()?.accessToken

--- a/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/AuthInterceptor.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/AuthInterceptor.kt
@@ -12,9 +12,10 @@ class AuthInterceptor
         private val localStorageDataSource: LocalStorageDataSource,
     ) : Interceptor {
         override fun intercept(chain: Interceptor.Chain): Response {
-            val accessToken = runBlocking {
-                localStorageDataSource.getAccessToken()
-            }
+            val accessToken =
+                runBlocking {
+                    localStorageDataSource.getAccessToken()
+                }
 
             val request =
                 chain

--- a/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/AuthInterceptor.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/AuthInterceptor.kt
@@ -1,0 +1,28 @@
+package com.catchmate.data.datasource.remote
+
+import com.catchmate.data.datasource.local.LocalStorageDataSource
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+
+class AuthInterceptor
+    @Inject
+    constructor(
+        private val localStorageDataSource: LocalStorageDataSource,
+    ) : Interceptor {
+        override fun intercept(chain: Interceptor.Chain): Response {
+            val accessToken = runBlocking {
+                localStorageDataSource.getAccessToken()
+            }
+
+            val request =
+                chain
+                    .request()
+                    .newBuilder()
+                    .header("AccessToken", accessToken)
+                    .build()
+
+            return chain.proceed(request)
+        }
+    }

--- a/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/AuthRetrofitClient.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/AuthRetrofitClient.kt
@@ -1,0 +1,28 @@
+package com.catchmate.data.datasource.remote
+
+import com.catchmate.data.BuildConfig
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Inject
+
+class AuthRetrofitClient @Inject constructor() {
+    private val logging =
+        HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BODY
+        }
+
+    private val okHttpClient =
+        OkHttpClient
+            .Builder()
+            .addInterceptor(logging)
+            .build()
+
+    val retrofit: AuthService = Retrofit.Builder()
+        .baseUrl(BuildConfig.SERVER_DOMAIN)
+        .client(okHttpClient)
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(AuthService::class.java)
+}

--- a/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/AuthRetrofitClient.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/AuthRetrofitClient.kt
@@ -7,22 +7,26 @@ import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import javax.inject.Inject
 
-class AuthRetrofitClient @Inject constructor() {
-    private val logging =
-        HttpLoggingInterceptor().apply {
-            level = HttpLoggingInterceptor.Level.BODY
-        }
+class AuthRetrofitClient
+    @Inject
+    constructor() {
+        private val logging =
+            HttpLoggingInterceptor().apply {
+                level = HttpLoggingInterceptor.Level.BODY
+            }
 
-    private val okHttpClient =
-        OkHttpClient
-            .Builder()
-            .addInterceptor(logging)
-            .build()
+        private val okHttpClient =
+            OkHttpClient
+                .Builder()
+                .addInterceptor(logging)
+                .build()
 
-    val retrofit: AuthService = Retrofit.Builder()
-        .baseUrl(BuildConfig.SERVER_DOMAIN)
-        .client(okHttpClient)
-        .addConverterFactory(GsonConverterFactory.create())
-        .build()
-        .create(AuthService::class.java)
-}
+        val retrofit: AuthService =
+            Retrofit
+                .Builder()
+                .baseUrl(BuildConfig.SERVER_DOMAIN)
+                .client(okHttpClient)
+                .addConverterFactory(GsonConverterFactory.create())
+                .build()
+                .create(AuthService::class.java)
+    }

--- a/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/AuthService.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/AuthService.kt
@@ -2,8 +2,10 @@ package com.catchmate.data.datasource.remote
 
 import com.catchmate.data.dto.LoginRequestDTO
 import com.catchmate.data.dto.LoginResponseDTO
+import com.catchmate.data.dto.ReissueResponseDTO
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.Header
 import retrofit2.http.POST
 
 interface AuthService {
@@ -11,4 +13,9 @@ interface AuthService {
     suspend fun postLogin(
         @Body loginRequestDTO: LoginRequestDTO,
     ): Response<LoginResponseDTO?>
+
+    @POST("auth/reissue")
+    suspend fun postReissue(
+        @Header("RefreshToken") refreshToken: String,
+    ): Response<ReissueResponseDTO?>
 }

--- a/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/BoardLikeService.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/BoardLikeService.kt
@@ -1,7 +1,6 @@
 package com.catchmate.data.datasource.remote
 
 import retrofit2.Response
-import retrofit2.http.Header
 import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query

--- a/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/BoardLikeService.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/BoardLikeService.kt
@@ -9,7 +9,6 @@ import retrofit2.http.Query
 interface BoardLikeService {
     @POST("board/like/{boardId}")
     suspend fun postBoardLike(
-        @Header("AccessToken") accessToken: String,
         @Path("boardId") boardId: Long,
         @Query("flag") flag: Int,
     ): Response<Int>

--- a/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/BoardListService.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/BoardListService.kt
@@ -3,7 +3,6 @@ package com.catchmate.data.datasource.remote
 import com.catchmate.data.dto.BoardListResponseDTO
 import retrofit2.Response
 import retrofit2.http.GET
-import retrofit2.http.Header
 import retrofit2.http.Path
 import retrofit2.http.Query
 

--- a/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/BoardListService.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/BoardListService.kt
@@ -10,7 +10,6 @@ import retrofit2.http.Query
 interface BoardListService {
     @GET("board/page/{pageNum}")
     suspend fun getBoardList(
-        @Header("AccessToken") accessToken: String,
         @Path("pageNum") pageNum: Long,
         @Query("gudans") gudans: String,
         @Query("people") people: Int,

--- a/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/BoardReadService.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/BoardReadService.kt
@@ -9,7 +9,6 @@ import retrofit2.http.Path
 interface BoardReadService {
     @GET("board/{boardId}")
     suspend fun getBoard(
-        @Header("AccessToken") accessToken: String,
         @Path("boardId") boardId: Long,
     ): Response<BoardReadResponseDTO?>
 }

--- a/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/BoardReadService.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/BoardReadService.kt
@@ -3,7 +3,6 @@ package com.catchmate.data.datasource.remote
 import com.catchmate.data.dto.BoardReadResponseDTO
 import retrofit2.Response
 import retrofit2.http.GET
-import retrofit2.http.Header
 import retrofit2.http.Path
 
 interface BoardReadService {

--- a/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/BoardWriteService.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/BoardWriteService.kt
@@ -10,7 +10,6 @@ import retrofit2.http.POST
 interface BoardWriteService {
     @POST("board/write")
     suspend fun postBoardWrite(
-        @Header("AccessToken") accessToken: String,
         @Body boardWriteRequestDTO: BoardWriteRequestDTO,
     ): Response<BoardWriteResponseDTO?>
 }

--- a/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/BoardWriteService.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/BoardWriteService.kt
@@ -4,7 +4,6 @@ import com.catchmate.data.dto.BoardWriteRequestDTO
 import com.catchmate.data.dto.BoardWriteResponseDTO
 import retrofit2.Response
 import retrofit2.http.Body
-import retrofit2.http.Header
 import retrofit2.http.POST
 
 interface BoardWriteService {

--- a/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/RetrofitClient.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/RetrofitClient.kt
@@ -15,6 +15,7 @@ class RetrofitClient
     @Inject
     constructor(
         localStorageDataSource: LocalStorageDataSource,
+        authAuthenticator: AuthAuthenticator,
     ) {
         private val logging =
             HttpLoggingInterceptor().apply {
@@ -50,6 +51,7 @@ class RetrofitClient
                 .Builder()
                 .addInterceptor(authInterceptor)
                 .addInterceptor(logging)
+                .authenticator(authAuthenticator)
                 .build()
 
         val retrofit: Retrofit by lazy {

--- a/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/SignUpService.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/SignUpService.kt
@@ -2,7 +2,7 @@ package com.catchmate.data.datasource.remote
 
 import com.catchmate.data.dto.CheckNicknameResponseDTO
 import com.catchmate.data.dto.UserAdditionalInfoRequestDTO
-import com.catchmate.data.dto.UserResponseDTO
+import com.catchmate.data.dto.UserAdditionalInfoResponseDTO
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -18,5 +18,5 @@ interface SignUpService {
     @POST("user/additional-info")
     suspend fun postUserAdditionalInfo(
         @Body userAdditionalInfoRequestDTO: UserAdditionalInfoRequestDTO,
-    ): Response<UserResponseDTO?>
+    ): Response<UserAdditionalInfoResponseDTO?>
 }

--- a/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/UserService.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/UserService.kt
@@ -1,0 +1,10 @@
+package com.catchmate.data.datasource.remote
+
+import com.catchmate.data.dto.GetUserProfileResponseDTO
+import retrofit2.Response
+import retrofit2.http.GET
+
+interface UserService {
+    @GET("user/profile")
+    suspend fun getUserProfile(): Response<GetUserProfileResponseDTO?>
+}

--- a/CatchMate/data/src/main/java/com/catchmate/data/di/AuthModule.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/di/AuthModule.kt
@@ -1,5 +1,8 @@
 package com.catchmate.data.di
 
+import com.catchmate.data.datasource.local.LocalStorageDataSource
+import com.catchmate.data.datasource.remote.AuthAuthenticator
+import com.catchmate.data.datasource.remote.AuthRetrofitClient
 import com.catchmate.data.repository.AuthRepositoryImpl
 import com.catchmate.domain.repository.AuthRepository
 import dagger.Module
@@ -12,4 +15,13 @@ import dagger.hilt.components.SingletonComponent
 object AuthModule {
     @Provides
     fun provideAuthRepository(authRepositoryImpl: AuthRepositoryImpl): AuthRepository = authRepositoryImpl
+
+    @Provides
+    fun provideAuthRetrofitClient(): AuthRetrofitClient = AuthRetrofitClient()
+
+    @Provides
+    fun provideAuthAuthenticator(
+        localStorageDataSource: LocalStorageDataSource,
+        authRetrofitClient: AuthRetrofitClient,
+    ): AuthAuthenticator = AuthAuthenticator(localStorageDataSource, authRetrofitClient)
 }

--- a/CatchMate/data/src/main/java/com/catchmate/data/di/UserModule.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/di/UserModule.kt
@@ -1,0 +1,15 @@
+package com.catchmate.data.di
+
+import com.catchmate.data.repository.UserRepositoryImpl
+import com.catchmate.domain.repository.UserRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+object UserModule {
+    @Provides
+    fun provideUserRepository(userRepositoryImpl: UserRepositoryImpl): UserRepository = userRepositoryImpl
+}

--- a/CatchMate/data/src/main/java/com/catchmate/data/dto/GetUserProfileResponseDTO.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/dto/GetUserProfileResponseDTO.kt
@@ -1,0 +1,14 @@
+package com.catchmate.data.dto
+
+data class GetUserProfileResponseDTO(
+    val userId: Long,
+    val email: String,
+    val picture: String,
+    val gender: String,
+    val pushAgreement: String,
+    val nickName: String,
+    val favoriteGudan: String,
+    val description: String?,
+    val birthDate: String,
+    val watchStyle: String?,
+)

--- a/CatchMate/data/src/main/java/com/catchmate/data/dto/ReissueResponseDTO.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/dto/ReissueResponseDTO.kt
@@ -1,0 +1,5 @@
+package com.catchmate.data.dto
+
+data class ReissueResponseDTO(
+    val accessToken: String,
+)

--- a/CatchMate/data/src/main/java/com/catchmate/data/dto/UserAdditionalInfoResponseDTO.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/dto/UserAdditionalInfoResponseDTO.kt
@@ -1,6 +1,6 @@
-package com.catchmate.domain.model
+package com.catchmate.data.dto
 
-data class UserResponse(
+data class UserAdditionalInfoResponseDTO(
     val accessToken: String,
     val refreshToken: String,
     val userId: Long,

--- a/CatchMate/data/src/main/java/com/catchmate/data/mapper/SignUpMapper.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/mapper/SignUpMapper.kt
@@ -2,10 +2,10 @@ package com.catchmate.data.mapper
 
 import com.catchmate.data.dto.CheckNicknameResponseDTO
 import com.catchmate.data.dto.UserAdditionalInfoRequestDTO
-import com.catchmate.data.dto.UserResponseDTO
+import com.catchmate.data.dto.UserAdditionalInfoResponseDTO
 import com.catchmate.domain.model.CheckNicknameResponse
 import com.catchmate.domain.model.UserAdditionalInfoRequest
-import com.catchmate.domain.model.UserResponse
+import com.catchmate.domain.model.UserAdditionalInfoResponse
 
 object SignUpMapper {
     fun toCheckNicknameResponse(checkNicknameResponseDTO: CheckNicknameResponseDTO): CheckNicknameResponse =
@@ -41,11 +41,11 @@ object SignUpMapper {
             watchStyle = userAdditionalInfoRequestDTO.watchStyle,
         )
 
-    fun toUserResponse(userResponseDTO: UserResponseDTO): UserResponse =
-        UserResponse(
-            accessToken = userResponseDTO.accessToken,
-            refreshToken = userResponseDTO.refreshToken,
-            userId = userResponseDTO.userId,
-            createdAt = userResponseDTO.createdAt,
+    fun toUserAdditionalInfoResponse(userAdditionalInfoResponseDTO: UserAdditionalInfoResponseDTO): UserAdditionalInfoResponse =
+        UserAdditionalInfoResponse(
+            accessToken = userAdditionalInfoResponseDTO.accessToken,
+            refreshToken = userAdditionalInfoResponseDTO.refreshToken,
+            userId = userAdditionalInfoResponseDTO.userId,
+            createdAt = userAdditionalInfoResponseDTO.createdAt,
         )
 }

--- a/CatchMate/data/src/main/java/com/catchmate/data/mapper/UserMapper.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/mapper/UserMapper.kt
@@ -1,0 +1,20 @@
+package com.catchmate.data.mapper
+
+import com.catchmate.data.dto.GetUserProfileResponseDTO
+import com.catchmate.domain.model.GetUserProfileResponse
+
+object UserMapper {
+    fun toUserProfileResponse(userProfileResponseDTO: GetUserProfileResponseDTO): GetUserProfileResponse =
+        GetUserProfileResponse(
+            userId = userProfileResponseDTO.userId,
+            email = userProfileResponseDTO.email,
+            picture = userProfileResponseDTO.picture,
+            gender = userProfileResponseDTO.gender,
+            pushAgreement = userProfileResponseDTO.pushAgreement,
+            nickName = userProfileResponseDTO.nickName,
+            favoriteGudan = userProfileResponseDTO.favoriteGudan,
+            description = userProfileResponseDTO.description,
+            birthDate = userProfileResponseDTO.birthDate,
+            watchStyle = userProfileResponseDTO.watchStyle,
+        )
+}

--- a/CatchMate/data/src/main/java/com/catchmate/data/repository/BoardLikeRepositoryImpl.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/repository/BoardLikeRepositoryImpl.kt
@@ -15,12 +15,11 @@ class BoardLikeRepositoryImpl
         private val boardLikeApi = retrofitClient.createApi<BoardLikeService>()
 
         override suspend fun postBoardLike(
-            accessToken: String,
             boardId: Long,
             flag: Int,
         ): Int? =
             try {
-                val response = boardLikeApi.postBoardLike(accessToken, boardId, flag)
+                val response = boardLikeApi.postBoardLike(boardId, flag)
                 if (response.isSuccessful) {
                     Log.d("BoardLikeRepository", "통신 성공 : ${response.code()}")
                     response.code()

--- a/CatchMate/data/src/main/java/com/catchmate/data/repository/BoardListRepositoryImpl.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/repository/BoardListRepositoryImpl.kt
@@ -17,14 +17,13 @@ class BoardListRepositoryImpl
         private val boardListApi = retrofitClient.createApi<BoardListService>()
 
         override suspend fun getBoardList(
-            accessToken: String,
             pageNum: Long,
             gudans: String,
             people: Int,
             gameDate: String,
         ): List<BoardListResponse>? =
             try {
-                val response = boardListApi.getBoardList(accessToken, pageNum, gudans, people, gameDate)
+                val response = boardListApi.getBoardList(pageNum, gudans, people, gameDate)
                 if (response.isSuccessful) {
                     Log.d("BoardListRepository", "통신 성공")
                     response.body()?.let { BoardListMapper.toBoardListResponse(it) } ?: throw Exception("Empty Response")

--- a/CatchMate/data/src/main/java/com/catchmate/data/repository/BoardListRepositoryImpl.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/repository/BoardListRepositoryImpl.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.catchmate.data.datasource.remote.BoardListService
 import com.catchmate.data.datasource.remote.RetrofitClient
 import com.catchmate.data.mapper.BoardListMapper
+import com.catchmate.domain.exception.ReissueFailureException
 import com.catchmate.domain.model.BoardListResponse
 import com.catchmate.domain.repository.BoardListRepository
 import org.json.JSONObject
@@ -21,19 +22,20 @@ class BoardListRepositoryImpl
             gudans: String,
             people: Int,
             gameDate: String,
-        ): List<BoardListResponse>? =
+        ): Result<List<BoardListResponse>> =
             try {
                 val response = boardListApi.getBoardList(pageNum, gudans, people, gameDate)
                 if (response.isSuccessful) {
                     Log.d("BoardListRepository", "통신 성공")
-                    response.body()?.let { BoardListMapper.toBoardListResponse(it) } ?: throw Exception("Empty Response")
+                    val body = response.body()?.let { BoardListMapper.toBoardListResponse(it) }
+                    Result.success(body ?: emptyList())
                 } else {
                     val stringToJson = JSONObject(response.errorBody()?.string()!!)
-                    Log.d("BoardListRepository", "통신 실패 : ${response.code()} - $stringToJson")
-                    null
+                    Result.failure(Exception("통신 실패 : ${response.code()} - $stringToJson"))
                 }
+            } catch (e: ReissueFailureException) {
+                Result.failure(e)
             } catch (e: Exception) {
-                e.printStackTrace()
-                null
+                Result.failure(e)
             }
     }

--- a/CatchMate/data/src/main/java/com/catchmate/data/repository/BoardReadRepositoryImpl.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/repository/BoardReadRepositoryImpl.kt
@@ -17,11 +17,10 @@ class BoardReadRepositoryImpl
         private val boardReadApi = retrofitClient.createApi<BoardReadService>()
 
         override suspend fun getBoard(
-            accessToken: String,
             boardId: Long,
         ): BoardReadResponse? =
             try {
-                val response = boardReadApi.getBoard(accessToken, boardId)
+                val response = boardReadApi.getBoard(boardId)
                 if (response.isSuccessful) {
                     Log.d("BoardReadRepository", "통신 성공 : ${response.code()}")
                     response.body()?.let { BoardReadMapper.toBoardReadResponse(it) } ?: throw Exception("Empty Response")

--- a/CatchMate/data/src/main/java/com/catchmate/data/repository/BoardReadRepositoryImpl.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/repository/BoardReadRepositoryImpl.kt
@@ -16,9 +16,7 @@ class BoardReadRepositoryImpl
     ) : BoardReadRepository {
         private val boardReadApi = retrofitClient.createApi<BoardReadService>()
 
-        override suspend fun getBoard(
-            boardId: Long,
-        ): BoardReadResponse? =
+        override suspend fun getBoard(boardId: Long): BoardReadResponse? =
             try {
                 val response = boardReadApi.getBoard(boardId)
                 if (response.isSuccessful) {

--- a/CatchMate/data/src/main/java/com/catchmate/data/repository/BoardWriteRepositoryImpl.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/repository/BoardWriteRepositoryImpl.kt
@@ -17,9 +17,7 @@ class BoardWriteRepositoryImpl
     ) : BoardWriteRepository {
         private val boardWriteApi = retrofitClient.createApi<BoardWriteService>()
 
-        override suspend fun postBoardWrite(
-            boardWriteRequest: BoardWriteRequest,
-        ): BoardWriteResponse? =
+        override suspend fun postBoardWrite(boardWriteRequest: BoardWriteRequest): BoardWriteResponse? =
             try {
                 val response = boardWriteApi.postBoardWrite(BoardWriteMapper.toBoardWriteRequestDTO(boardWriteRequest))
                 if (response.isSuccessful) {

--- a/CatchMate/data/src/main/java/com/catchmate/data/repository/BoardWriteRepositoryImpl.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/repository/BoardWriteRepositoryImpl.kt
@@ -18,11 +18,10 @@ class BoardWriteRepositoryImpl
         private val boardWriteApi = retrofitClient.createApi<BoardWriteService>()
 
         override suspend fun postBoardWrite(
-            accessToken: String,
             boardWriteRequest: BoardWriteRequest,
         ): BoardWriteResponse? =
             try {
-                val response = boardWriteApi.postBoardWrite(accessToken, BoardWriteMapper.toBoardWriteRequestDTO(boardWriteRequest))
+                val response = boardWriteApi.postBoardWrite(BoardWriteMapper.toBoardWriteRequestDTO(boardWriteRequest))
                 if (response.isSuccessful) {
                     Log.d("BoardWriteRepository", "통신 성공 : ${response.code()}")
                     response.body()?.let { BoardWriteMapper.toBoardWriteResponse(it) } ?: throw Exception("Empty Response")

--- a/CatchMate/data/src/main/java/com/catchmate/data/repository/LocalDataRepositoryImpl.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/repository/LocalDataRepositoryImpl.kt
@@ -17,11 +17,21 @@ class LocalDataRepositoryImpl
             localStorageDataSource.saveRefreshToken(refreshToken)
         }
 
+        override fun saveUserId(userId: Long) {
+            localStorageDataSource.saveUserId(userId)
+        }
+
         override fun getAccessToken(): String = localStorageDataSource.getAccessToken()
 
         override fun getRefreshToken(): String = localStorageDataSource.getRefreshToken()
 
+        override fun getUserId(): Long = localStorageDataSource.getUserId()
+
         override fun removeTokens() {
             localStorageDataSource.removeTokens()
+        }
+
+        override fun removeUserId() {
+            localStorageDataSource.removeUserId()
         }
     }

--- a/CatchMate/data/src/main/java/com/catchmate/data/repository/SignUpRepositoryImpl.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/repository/SignUpRepositoryImpl.kt
@@ -6,7 +6,7 @@ import com.catchmate.data.datasource.remote.SignUpService
 import com.catchmate.data.mapper.SignUpMapper
 import com.catchmate.domain.model.CheckNicknameResponse
 import com.catchmate.domain.model.UserAdditionalInfoRequest
-import com.catchmate.domain.model.UserResponse
+import com.catchmate.domain.model.UserAdditionalInfoResponse
 import com.catchmate.domain.repository.SignUpRepository
 import org.json.JSONObject
 import javax.inject.Inject
@@ -33,7 +33,7 @@ class SignUpRepositoryImpl
                 null
             }
 
-        override suspend fun postUserAdditionalInfo(userAdditionalInfoRequest: UserAdditionalInfoRequest): UserResponse? =
+        override suspend fun postUserAdditionalInfo(userAdditionalInfoRequest: UserAdditionalInfoRequest): UserAdditionalInfoResponse? =
             try {
                 val response =
                     signUpApi
@@ -43,7 +43,7 @@ class SignUpRepositoryImpl
                         )
                 if (response.isSuccessful) {
                     Log.d("SignUpRepo", "통신 성공 ${response.code()}")
-                    response.body()?.let { SignUpMapper.toUserResponse(it) } ?: throw Exception("Empty Response")
+                    response.body()?.let { SignUpMapper.toUserAdditionalInfoResponse(it) } ?: throw Exception("Empty Response")
                 } else {
                     val stringToJson = JSONObject(response.errorBody()?.string()!!)
                     Log.d("SignUpRepo", "통신 실패 ${response.code()}\n$stringToJson")

--- a/CatchMate/data/src/main/java/com/catchmate/data/repository/UserRepositoryImpl.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/repository/UserRepositoryImpl.kt
@@ -1,0 +1,34 @@
+package com.catchmate.data.repository
+
+import android.util.Log
+import com.catchmate.data.datasource.remote.RetrofitClient
+import com.catchmate.data.datasource.remote.UserService
+import com.catchmate.data.mapper.UserMapper
+import com.catchmate.domain.model.GetUserProfileResponse
+import com.catchmate.domain.repository.UserRepository
+import org.json.JSONObject
+import javax.inject.Inject
+
+class UserRepositoryImpl
+    @Inject
+    constructor(
+        retrofitClient: RetrofitClient,
+    ) : UserRepository {
+        private val userApi = retrofitClient.createApi<UserService>()
+
+        override suspend fun getUserProfile(): GetUserProfileResponse? =
+            try {
+                val response = userApi.getUserProfile()
+                if (response.isSuccessful) {
+                    Log.d("UserProfileRepo", "통신 성공 : ${response.code()}")
+                    response.body()?.let { UserMapper.toUserProfileResponse(it) } ?: throw Exception("Empty Response")
+                } else {
+                    val stringToJson = JSONObject(response.errorBody()?.string()!!)
+                    Log.d("UserProfileRepo", "통신 실패 ${response.code()}\n$stringToJson")
+                    null
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+                null
+            }
+    }

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/exception/ReissueFailureException.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/exception/ReissueFailureException.kt
@@ -1,0 +1,5 @@
+package com.catchmate.domain.exception
+
+import java.io.IOException
+
+class ReissueFailureException(message: String) : IOException(message)

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/exception/ReissueFailureException.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/exception/ReissueFailureException.kt
@@ -2,4 +2,6 @@ package com.catchmate.domain.exception
 
 import java.io.IOException
 
-class ReissueFailureException(message: String) : IOException(message)
+class ReissueFailureException(
+    message: String,
+) : IOException(message)

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/model/GetUserProfileResponse.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/model/GetUserProfileResponse.kt
@@ -1,0 +1,14 @@
+package com.catchmate.domain.model
+
+data class GetUserProfileResponse(
+    val userId: Long,
+    val email: String,
+    val picture: String,
+    val gender: String,
+    val pushAgreement: String,
+    val nickName: String,
+    val favoriteGudan: String,
+    val description: String?,
+    val birthDate: String,
+    val watchStyle: String?,
+)

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/model/UserAdditionalInfoResponse.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/model/UserAdditionalInfoResponse.kt
@@ -1,6 +1,6 @@
-package com.catchmate.data.dto
+package com.catchmate.domain.model
 
-data class UserResponseDTO(
+data class UserAdditionalInfoResponse(
     val accessToken: String,
     val refreshToken: String,
     val userId: Long,

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/repository/BoardLikeRepository.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/repository/BoardLikeRepository.kt
@@ -2,7 +2,6 @@ package com.catchmate.domain.repository
 
 interface BoardLikeRepository {
     suspend fun postBoardLike(
-        accessToken: String,
         boardId: Long,
         flag: Int,
     ): Int?

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/repository/BoardListRepository.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/repository/BoardListRepository.kt
@@ -8,5 +8,5 @@ interface BoardListRepository {
         gudans: String,
         people: Int,
         gameDate: String,
-    ): List<BoardListResponse>?
+    ): Result<List<BoardListResponse>>
 }

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/repository/BoardListRepository.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/repository/BoardListRepository.kt
@@ -4,7 +4,6 @@ import com.catchmate.domain.model.BoardListResponse
 
 interface BoardListRepository {
     suspend fun getBoardList(
-        accessToken: String,
         pageNum: Long,
         gudans: String,
         people: Int,

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/repository/BoardReadRepository.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/repository/BoardReadRepository.kt
@@ -3,7 +3,5 @@ package com.catchmate.domain.repository
 import com.catchmate.domain.model.BoardReadResponse
 
 interface BoardReadRepository {
-    suspend fun getBoard(
-        boardId: Long,
-    ): BoardReadResponse?
+    suspend fun getBoard(boardId: Long): BoardReadResponse?
 }

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/repository/BoardReadRepository.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/repository/BoardReadRepository.kt
@@ -4,7 +4,6 @@ import com.catchmate.domain.model.BoardReadResponse
 
 interface BoardReadRepository {
     suspend fun getBoard(
-        accessToken: String,
         boardId: Long,
     ): BoardReadResponse?
 }

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/repository/BoardWriteRepository.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/repository/BoardWriteRepository.kt
@@ -4,7 +4,5 @@ import com.catchmate.domain.model.BoardWriteRequest
 import com.catchmate.domain.model.BoardWriteResponse
 
 interface BoardWriteRepository {
-    suspend fun postBoardWrite(
-        boardWriteRequest: BoardWriteRequest,
-    ): BoardWriteResponse?
+    suspend fun postBoardWrite(boardWriteRequest: BoardWriteRequest): BoardWriteResponse?
 }

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/repository/BoardWriteRepository.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/repository/BoardWriteRepository.kt
@@ -5,7 +5,6 @@ import com.catchmate.domain.model.BoardWriteResponse
 
 interface BoardWriteRepository {
     suspend fun postBoardWrite(
-        accessToken: String,
         boardWriteRequest: BoardWriteRequest,
     ): BoardWriteResponse?
 }

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/repository/LocalDataRepository.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/repository/LocalDataRepository.kt
@@ -5,9 +5,15 @@ interface LocalDataRepository {
 
     fun saveRefreshToken(refreshToken: String)
 
+    fun saveUserId(userId: Long)
+
     fun getAccessToken(): String
 
     fun getRefreshToken(): String
 
+    fun getUserId(): Long
+
     fun removeTokens()
+
+    fun removeUserId()
 }

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/repository/SignUpRepository.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/repository/SignUpRepository.kt
@@ -2,10 +2,10 @@ package com.catchmate.domain.repository
 
 import com.catchmate.domain.model.CheckNicknameResponse
 import com.catchmate.domain.model.UserAdditionalInfoRequest
-import com.catchmate.domain.model.UserResponse
+import com.catchmate.domain.model.UserAdditionalInfoResponse
 
 interface SignUpRepository {
     suspend fun getNicknameAvailability(nickName: String): CheckNicknameResponse?
 
-    suspend fun postUserAdditionalInfo(userAdditionalInfoRequest: UserAdditionalInfoRequest): UserResponse?
+    suspend fun postUserAdditionalInfo(userAdditionalInfoRequest: UserAdditionalInfoRequest): UserAdditionalInfoResponse?
 }

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/repository/UserRepository.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/repository/UserRepository.kt
@@ -1,0 +1,7 @@
+package com.catchmate.domain.repository
+
+import com.catchmate.domain.model.GetUserProfileResponse
+
+interface UserRepository {
+    suspend fun getUserProfile(): GetUserProfileResponse?
+}

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/usecase/BoardLikeUseCase.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/usecase/BoardLikeUseCase.kt
@@ -9,8 +9,7 @@ class BoardLikeUseCase
         private val boardLikeRepository: BoardLikeRepository,
     ) {
         suspend fun postBoardLike(
-            accessToken: String,
             boardId: Long,
             flag: Int,
-        ): Int? = boardLikeRepository.postBoardLike(accessToken, boardId, flag)
+        ): Int? = boardLikeRepository.postBoardLike(boardId, flag)
     }

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/usecase/BoardListUseCase.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/usecase/BoardListUseCase.kt
@@ -14,5 +14,5 @@ class BoardListUseCase
             gudans: String,
             people: Int,
             gameDate: String,
-        ): List<BoardListResponse>? = boardListRepository.getBoardList(accessToken, pageNum, gudans, people, gameDate)
+        ): Result<List<BoardListResponse>> = boardListRepository.getBoardList(pageNum, gudans, people, gameDate)
     }

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/usecase/BoardListUseCase.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/usecase/BoardListUseCase.kt
@@ -10,7 +10,6 @@ class BoardListUseCase
         private val boardListRepository: BoardListRepository,
     ) {
         suspend fun getBoardList(
-            accessToken: String,
             pageNum: Long,
             gudans: String,
             people: Int,

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/usecase/BoardReadUseCase.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/usecase/BoardReadUseCase.kt
@@ -10,7 +10,6 @@ class BoardReadUseCase
         private val boardReadRepository: BoardReadRepository,
     ) {
         suspend fun getBoard(
-            accessToken: String,
             boardId: Long,
-        ): BoardReadResponse? = boardReadRepository.getBoard(accessToken, boardId)
+        ): BoardReadResponse? = boardReadRepository.getBoard(boardId)
     }

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/usecase/BoardReadUseCase.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/usecase/BoardReadUseCase.kt
@@ -9,7 +9,5 @@ class BoardReadUseCase
     constructor(
         private val boardReadRepository: BoardReadRepository,
     ) {
-        suspend fun getBoard(
-            boardId: Long,
-        ): BoardReadResponse? = boardReadRepository.getBoard(boardId)
+        suspend fun getBoard(boardId: Long): BoardReadResponse? = boardReadRepository.getBoard(boardId)
     }

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/usecase/BoardWriteUseCase.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/usecase/BoardWriteUseCase.kt
@@ -10,7 +10,6 @@ class BoardWriteUseCase
     constructor(
         private val boardWriteRepository: BoardWriteRepository,
     ) {
-        suspend fun postBoardWrite(
-            boardWriteRequest: BoardWriteRequest,
-        ): BoardWriteResponse? = boardWriteRepository.postBoardWrite(boardWriteRequest)
+        suspend fun postBoardWrite(boardWriteRequest: BoardWriteRequest): BoardWriteResponse? =
+            boardWriteRepository.postBoardWrite(boardWriteRequest)
     }

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/usecase/BoardWriteUseCase.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/usecase/BoardWriteUseCase.kt
@@ -11,7 +11,6 @@ class BoardWriteUseCase
         private val boardWriteRepository: BoardWriteRepository,
     ) {
         suspend fun postBoardWrite(
-            accessToken: String,
             boardWriteRequest: BoardWriteRequest,
-        ): BoardWriteResponse? = boardWriteRepository.postBoardWrite(accessToken, boardWriteRequest)
+        ): BoardWriteResponse? = boardWriteRepository.postBoardWrite(boardWriteRequest)
     }

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/usecase/LocalDataUseCase.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/usecase/LocalDataUseCase.kt
@@ -16,11 +16,21 @@ class LocalDataUseCase
             localDataRepository.saveRefreshToken(refreshToken)
         }
 
+        fun saveUserId(userId: Long) {
+            localDataRepository.saveUserId(userId)
+        }
+
         fun getAccessToken(): String = localDataRepository.getAccessToken()
 
         fun getRefreshToken(): String = localDataRepository.getRefreshToken()
 
+        fun getUserId(): Long = localDataRepository.getUserId()
+
         fun removeTokens() {
             localDataRepository.removeTokens()
+        }
+
+        fun removeUserId() {
+            localDataRepository.removeUserId()
         }
     }

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/usecase/SignUpUseCase.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/usecase/SignUpUseCase.kt
@@ -2,7 +2,7 @@ package com.catchmate.domain.usecase
 
 import com.catchmate.domain.model.CheckNicknameResponse
 import com.catchmate.domain.model.UserAdditionalInfoRequest
-import com.catchmate.domain.model.UserResponse
+import com.catchmate.domain.model.UserAdditionalInfoResponse
 import com.catchmate.domain.repository.SignUpRepository
 import javax.inject.Inject
 
@@ -13,6 +13,6 @@ class SignUpUseCase
     ) {
         suspend fun getNicknameAvailability(nickName: String): CheckNicknameResponse? = signUpRepository.getNicknameAvailability(nickName)
 
-        suspend fun postUserAdditionalInfo(userAdditionalInfoRequest: UserAdditionalInfoRequest): UserResponse? =
+        suspend fun postUserAdditionalInfo(userAdditionalInfoRequest: UserAdditionalInfoRequest): UserAdditionalInfoResponse? =
             signUpRepository.postUserAdditionalInfo(userAdditionalInfoRequest)
     }

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/usecase/UserUseCase.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/usecase/UserUseCase.kt
@@ -1,0 +1,13 @@
+package com.catchmate.domain.usecase
+
+import com.catchmate.domain.model.GetUserProfileResponse
+import com.catchmate.domain.repository.UserRepository
+import javax.inject.Inject
+
+class UserUseCase
+    @Inject
+    constructor(
+        private val userRepository: UserRepository,
+    ) {
+        suspend fun getUserProfile(): GetUserProfileResponse? = userRepository.getUserProfile()
+    }

--- a/CatchMate/gradle/libs.versions.toml
+++ b/CatchMate/gradle/libs.versions.toml
@@ -44,8 +44,9 @@ googleid = "1.1.1"
 google-services = "4.4.2"
 firebase-bom = "33.1.2"
 
-# Retrofit
+# Retrofit, Okhttp
 retrofit = "2.11.0"
+okhttp = "4.12.0"
 
 # Glide
 glide = "4.16.0"
@@ -94,6 +95,9 @@ firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.r
 firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging" }
 
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
+okhttp-bom = { group = "com.squareup.okhttp3", name = "okhttp-bom", version.ref = "okhttp"}
+okhttp = { group = "com.squareup.okhttp3", name = "okhttp" }
+logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor" }
 
 glide = { group = "com.github.bumptech.glide", name = "glide", version.ref = "glide" }
 

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/home/HomeFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/home/HomeFragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.navigation.NavOptions
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -97,15 +98,35 @@ class HomeFragment :
         homeViewModel.getBoardList(
             pageNum = page++,
         )
-        homeViewModel.boardListResponse.observe(viewLifecycleOwner) { response ->
-            if (response.isNotEmpty()) {
-                Log.e("게시글 목록 존재", response.size.toString())
-                isNextPageExist = true
-                val adapter = binding.rvHomePosts.adapter as HomePostAdapter
-                adapter.updatePostList(response)
-            } else {
-                Log.e("게시글 목록 더이상 없음", response.size.toString())
-                isNextPageExist = false
+        homeViewModel.boardListResponse.observe(viewLifecycleOwner) { boardList ->
+            boardList?.let {
+                if (boardList.isNotEmpty()) {
+                    Log.e("게시글 목록 존재", boardList.size.toString())
+                    isNextPageExist = true
+                    val adapter = binding.rvHomePosts.adapter as HomePostAdapter
+                    adapter.updatePostList(boardList)
+                } else {
+                    // page 1일때 아닐때로 분기해서 게시글 목록이 아예 없는지 구분 필요
+                    Log.e("게시글 목록 더이상 없음", boardList.size.toString())
+                    isNextPageExist = false
+                }
+            }
+        }
+
+        homeViewModel.navigateToLogin.observe(viewLifecycleOwner) { isTrue ->
+            if (isTrue) {
+                val navOptions =
+                    NavOptions
+                        .Builder()
+                        .setPopUpTo(R.id.homeFragment, true)
+                        .build()
+                findNavController().navigate(R.id.action_homeFragment_to_loginFragment, null, navOptions)
+            }
+        }
+
+        homeViewModel.errorMessage.observe(viewLifecycleOwner) { errorMessage ->
+            errorMessage?.let {
+                Log.e("Reissue Error", it)
             }
         }
     }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/home/HomeFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/home/HomeFragment.kt
@@ -88,7 +88,6 @@ class HomeFragment :
     private fun initViewModel() {
         homeViewModel.getBoardList(
             pageNum = page++,
-            accessToken = accessToken,
         )
         homeViewModel.boardListResponse.observe(viewLifecycleOwner) { response ->
             if (response.isNotEmpty()) {
@@ -145,7 +144,6 @@ class HomeFragment :
                             if (isNextPageExist) {
                                 homeViewModel.getBoardList(
                                     pageNum = page++,
-                                    accessToken = accessToken,
                                 )
                             }
                         }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/home/HomeFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/home/HomeFragment.kt
@@ -15,6 +15,7 @@ import com.catchmate.presentation.databinding.FragmentHomeBinding
 import com.catchmate.presentation.interaction.OnPostItemClickListener
 import com.catchmate.presentation.viewmodel.HomeViewModel
 import com.catchmate.presentation.viewmodel.LocalDataViewMdoel
+import com.catchmate.presentation.viewmodel.UserViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -26,6 +27,7 @@ class HomeFragment :
 
     private val homeViewModel: HomeViewModel by viewModels()
     private val localDataViewModel: LocalDataViewMdoel by viewModels()
+    private val userViewModel: UserViewModel by viewModels()
 
     private lateinit var accessToken: String
     private lateinit var refreshToken: String
@@ -64,6 +66,7 @@ class HomeFragment :
     private fun getTokens() {
         localDataViewModel.getAccessToken()
         localDataViewModel.getRefreshToken()
+        localDataViewModel.getUserId()
         localDataViewModel.accessToken.observe(viewLifecycleOwner) { accessToken ->
             if (accessToken != null) {
                 this.accessToken = accessToken
@@ -73,6 +76,11 @@ class HomeFragment :
         localDataViewModel.refreshToken.observe(viewLifecycleOwner) { refreshToken ->
             if (refreshToken != null) {
                 this.refreshToken = refreshToken
+            }
+        }
+        localDataViewModel.userId.observe(viewLifecycleOwner) { userId ->
+            if (userId == -1L) {
+                getUserProfile()
             }
         }
     }
@@ -150,6 +158,15 @@ class HomeFragment :
                     }
                 },
             )
+        }
+    }
+
+    private fun getUserProfile() {
+        userViewModel.getUserProfile()
+        userViewModel.userProfile.observe(viewLifecycleOwner) { response ->
+            response?.let {
+                localDataViewModel.saveUserId(response.userId)
+            }
         }
     }
 

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/onboarding/CheerStyleOnboardingFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/onboarding/CheerStyleOnboardingFragment.kt
@@ -129,7 +129,7 @@ class CheerStyleOnboardingFragment : Fragment() {
 
     private fun postUserAdditionalInfo(userAdditionalInfoRequest: UserAdditionalInfoRequest) {
         signUpViewModel.postUserAdditionalInfo(userAdditionalInfoRequest)
-        signUpViewModel.userResponse.observe(viewLifecycleOwner) { response ->
+        signUpViewModel.userAdditionalInfoResponse.observe(viewLifecycleOwner) { response ->
             if (response != null) {
                 Log.d("response", "${response.userId}\n${response.accessToken}\n${response.refreshToken}")
                 localDataViewModel.saveAccessToken(response.accessToken)

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/onboarding/CheerStyleOnboardingFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/onboarding/CheerStyleOnboardingFragment.kt
@@ -88,7 +88,6 @@ class CheerStyleOnboardingFragment : Fragment() {
                             .replace(" 스타일", ""),
                     )
                 postUserAdditionalInfo(newUserInfo)
-                findNavController().navigate(R.id.action_cheerStyleOnboardingFragment_to_signupCompleteFragment)
             }
         }
     }
@@ -134,6 +133,8 @@ class CheerStyleOnboardingFragment : Fragment() {
                 Log.d("response", "${response.userId}\n${response.accessToken}\n${response.refreshToken}")
                 localDataViewModel.saveAccessToken(response.accessToken)
                 localDataViewModel.saveRefreshToken(response.refreshToken)
+                localDataViewModel.saveUserId(response.userId)
+                findNavController().navigate(R.id.action_cheerStyleOnboardingFragment_to_signupCompleteFragment)
             }
         }
     }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/AddPostFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/AddPostFragment.kt
@@ -193,7 +193,6 @@ class AddPostFragment :
                     )
 
                 addPostViewModel.postBoardWrite(
-                    localDataViewModel.accessToken.value!!,
                     boardWriteRequest,
                 )
             }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/ReadPostFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/ReadPostFragment.kt
@@ -79,7 +79,7 @@ class ReadPostFragment : Fragment() {
         localDataViewModel.accessToken.observe(viewLifecycleOwner) { accessToken ->
             if (accessToken != null) {
                 this.accessToken = accessToken
-                readPostViewModel.getBoard(accessToken, boardId)
+                readPostViewModel.getBoard(boardId)
             }
         }
         localDataViewModel.refreshToken.observe(viewLifecycleOwner) { refreshToken ->
@@ -137,9 +137,9 @@ class ReadPostFragment : Fragment() {
             }
             toggleLikedFooterLiked.setOnCheckedChangeListener { _, isChecked ->
                 if (isChecked) {
-                    readPostViewModel.postBoardLike(accessToken, boardId, 1)
+                    readPostViewModel.run { postBoardLike( boardId, 1) }
                 } else {
-                    readPostViewModel.postBoardLike(accessToken, boardId, 0)
+                    readPostViewModel.postBoardLike(boardId, 0)
                 }
             }
         }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/ReadPostFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/ReadPostFragment.kt
@@ -137,7 +137,7 @@ class ReadPostFragment : Fragment() {
             }
             toggleLikedFooterLiked.setOnCheckedChangeListener { _, isChecked ->
                 if (isChecked) {
-                    readPostViewModel.run { postBoardLike( boardId, 1) }
+                    readPostViewModel.run { postBoardLike(boardId, 1) }
                 } else {
                     readPostViewModel.postBoardLike(boardId, 0)
                 }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/viewmodel/AddPostViewModel.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/viewmodel/AddPostViewModel.kt
@@ -45,9 +45,7 @@ class AddPostViewModel
             _gameDateTime.value = gameDateTime
         }
 
-        fun postBoardWrite(
-            boardWriteRequest: BoardWriteRequest,
-        ) {
+        fun postBoardWrite(boardWriteRequest: BoardWriteRequest) {
             viewModelScope.launch {
                 _boardWriteResponse.value = boardWriteUseCase.postBoardWrite(boardWriteRequest)
             }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/viewmodel/AddPostViewModel.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/viewmodel/AddPostViewModel.kt
@@ -46,11 +46,10 @@ class AddPostViewModel
         }
 
         fun postBoardWrite(
-            accessToken: String,
             boardWriteRequest: BoardWriteRequest,
         ) {
             viewModelScope.launch {
-                _boardWriteResponse.value = boardWriteUseCase.postBoardWrite(accessToken, boardWriteRequest)
+                _boardWriteResponse.value = boardWriteUseCase.postBoardWrite(boardWriteRequest)
             }
         }
     }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/viewmodel/HomeViewModel.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/viewmodel/HomeViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.catchmate.domain.exception.ReissueFailureException
 import com.catchmate.domain.model.BoardListResponse
 import com.catchmate.domain.usecase.BoardListUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -16,9 +17,17 @@ class HomeViewModel
     constructor(
         private val boardListUseCase: BoardListUseCase,
     ) : ViewModel() {
-        private val _boardListResponse = MutableLiveData<List<BoardListResponse>>()
-        val boardListResponse: LiveData<List<BoardListResponse>>
+        private val _boardListResponse = MutableLiveData<List<BoardListResponse>?>()
+        val boardListResponse: LiveData<List<BoardListResponse>?>
             get() = _boardListResponse
+
+        private val _errorMessage = MutableLiveData<String?>()
+        val errorMessage: LiveData<String?>
+            get() = _errorMessage
+
+        private val _navigateToLogin = MutableLiveData<Boolean>()
+        val navigateToLogin: LiveData<Boolean>
+            get() = _navigateToLogin
 
         fun getBoardList(
             pageNum: Long,
@@ -27,7 +36,17 @@ class HomeViewModel
             gameDate: String = "9999-99-99",
         ) {
             viewModelScope.launch {
-                _boardListResponse.value = boardListUseCase.getBoardList(accessToken, pageNum, gudans, people, gameDate)
+                val result =  boardListUseCase.getBoardList(pageNum, gudans, people, gameDate)
+
+                result.onSuccess { boardList ->
+                    _boardListResponse.value = boardList
+                }.onFailure { exception ->
+                    if (exception is ReissueFailureException) {
+                        _navigateToLogin.value = true
+                    } else {
+                        _errorMessage.value = exception.message
+                    }
+                }
             }
         }
     }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/viewmodel/HomeViewModel.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/viewmodel/HomeViewModel.kt
@@ -36,17 +36,18 @@ class HomeViewModel
             gameDate: String = "9999-99-99",
         ) {
             viewModelScope.launch {
-                val result =  boardListUseCase.getBoardList(pageNum, gudans, people, gameDate)
+                val result = boardListUseCase.getBoardList(pageNum, gudans, people, gameDate)
 
-                result.onSuccess { boardList ->
-                    _boardListResponse.value = boardList
-                }.onFailure { exception ->
-                    if (exception is ReissueFailureException) {
-                        _navigateToLogin.value = true
-                    } else {
-                        _errorMessage.value = exception.message
+                result
+                    .onSuccess { boardList ->
+                        _boardListResponse.value = boardList
+                    }.onFailure { exception ->
+                        if (exception is ReissueFailureException) {
+                            _navigateToLogin.value = true
+                        } else {
+                            _errorMessage.value = exception.message
+                        }
                     }
-                }
             }
         }
     }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/viewmodel/HomeViewModel.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/viewmodel/HomeViewModel.kt
@@ -21,7 +21,6 @@ class HomeViewModel
             get() = _boardListResponse
 
         fun getBoardList(
-            accessToken: String,
             pageNum: Long,
             gudans: String = "",
             people: Int = 0,

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/viewmodel/LocalDataViewMdoel.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/viewmodel/LocalDataViewMdoel.kt
@@ -21,6 +21,10 @@ class LocalDataViewMdoel
         val refreshToken: LiveData<String>
             get() = _refreshToken
 
+        private var _userId = MutableLiveData<Long>()
+        val userId: LiveData<Long>
+            get() = _userId
+
         fun saveAccessToken(accessToken: String) {
             localDataUseCase.saveAccessToken(accessToken)
         }
@@ -29,11 +33,19 @@ class LocalDataViewMdoel
             localDataUseCase.saveRefreshToken(refreshToken)
         }
 
+        fun saveUserId(userId: Long) {
+            localDataUseCase.saveUserId(userId)
+        }
+
         fun getAccessToken() {
             _accessToken.value = localDataUseCase.getAccessToken()
         }
 
         fun getRefreshToken() {
             _refreshToken.value = localDataUseCase.getRefreshToken()
+        }
+
+        fun getUserId() {
+            _userId.value = localDataUseCase.getUserId()
         }
     }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/viewmodel/ReadPostViewModel.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/viewmodel/ReadPostViewModel.kt
@@ -26,9 +26,7 @@ class ReadPostViewModel
         val boardLikeResponse: LiveData<Int>
             get() = _boardLikeResponse
 
-        fun getBoard(
-            boardId: Long,
-        ) {
+        fun getBoard(boardId: Long) {
             viewModelScope.launch {
                 _boardReadResponse.value = boardReadUseCase.getBoard(boardId)
             }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/viewmodel/ReadPostViewModel.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/viewmodel/ReadPostViewModel.kt
@@ -27,21 +27,19 @@ class ReadPostViewModel
             get() = _boardLikeResponse
 
         fun getBoard(
-            accessToken: String,
             boardId: Long,
         ) {
             viewModelScope.launch {
-                _boardReadResponse.value = boardReadUseCase.getBoard(accessToken, boardId)
+                _boardReadResponse.value = boardReadUseCase.getBoard(boardId)
             }
         }
 
         fun postBoardLike(
-            accessToken: String,
             boardId: Long,
             flag: Int,
         ) {
             viewModelScope.launch {
-                _boardLikeResponse.value = boardLikeUseCase.postBoardLike(accessToken, boardId, flag)
+                _boardLikeResponse.value = boardLikeUseCase.postBoardLike(boardId, flag)
             }
         }
     }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/viewmodel/SignUpViewModel.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/viewmodel/SignUpViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.catchmate.domain.model.CheckNicknameResponse
 import com.catchmate.domain.model.UserAdditionalInfoRequest
-import com.catchmate.domain.model.UserResponse
+import com.catchmate.domain.model.UserAdditionalInfoResponse
 import com.catchmate.domain.usecase.SignUpUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -22,9 +22,9 @@ class SignUpViewModel
         val checkNicknameResponse: LiveData<CheckNicknameResponse>
             get() = _checkNicknameResponse
 
-        private var _userResponse = MutableLiveData<UserResponse>()
-        val userResponse
-            get() = _userResponse
+        private var _userAdditionalInfoResponse = MutableLiveData<UserAdditionalInfoResponse>()
+        val userAdditionalInfoResponse
+            get() = _userAdditionalInfoResponse
 
         fun getNicknameAvailability(nickName: String) {
             viewModelScope.launch {
@@ -34,7 +34,7 @@ class SignUpViewModel
 
         fun postUserAdditionalInfo(userAdditionalInfoRequest: UserAdditionalInfoRequest) {
             viewModelScope.launch {
-                _userResponse.value = signUpUseCase.postUserAdditionalInfo(userAdditionalInfoRequest)
+                _userAdditionalInfoResponse.value = signUpUseCase.postUserAdditionalInfo(userAdditionalInfoRequest)
             }
         }
     }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/viewmodel/UserViewModel.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/viewmodel/UserViewModel.kt
@@ -1,0 +1,28 @@
+package com.catchmate.presentation.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.catchmate.domain.model.GetUserProfileResponse
+import com.catchmate.domain.usecase.UserUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class UserViewModel
+    @Inject
+    constructor(
+        private val userUseCase: UserUseCase,
+    ) : ViewModel() {
+        private val _userProfile = MutableLiveData<GetUserProfileResponse?>()
+        val userProfile: LiveData<GetUserProfileResponse?>
+            get() = _userProfile
+
+        fun getUserProfile() {
+            viewModelScope.launch {
+                _userProfile.value = userUseCase.getUserProfile()
+            }
+        }
+    }

--- a/CatchMate/presentation/src/main/res/navigation/nav_graph.xml
+++ b/CatchMate/presentation/src/main/res/navigation/nav_graph.xml
@@ -58,6 +58,9 @@
         <action
             android:id="@+id/action_homeFragment_to_readPostFragment"
             app:destination="@id/readPostFragment" />
+        <action
+            android:id="@+id/action_homeFragment_to_loginFragment"
+            app:destination="@id/loginFragment" />
     </fragment>
     <fragment
         android:id="@+id/notificationFragment"


### PR DESCRIPTION
## 관련 이슈
- Close #51 
<br>

## 작업 내용
- interceptor 를 등록해 api 통신 시 header로 access token 담아 요청 전송하도록 함
- authenticator 를 등록해 interceptor로 api 요청 시 401 반환될 경우 토큰 재발급 처리하도록 함
- shared preference 객체에 userId 저장하는 로직 구현
<br>

## 참고 사항
refresh token 만료 시 에러 처리 부분 테스트 필요
