### PR TITLE
fix: 게시글 관련 수정

### DIFF
--- a/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/EnrollService.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/datasource/remote/EnrollService.kt
@@ -5,6 +5,7 @@ import com.catchmate.data.dto.enroll.GetAllReceivedEnrollResponseDTO
 import com.catchmate.data.dto.enroll.GetEnrollNewCountResponseDTO
 import com.catchmate.data.dto.enroll.GetReceivedEnrollResponseDTO
 import com.catchmate.data.dto.enroll.GetRequestedEnrollListResponseDTO
+import com.catchmate.data.dto.enroll.GetRequestedEnrollResponseDTO
 import com.catchmate.data.dto.enroll.PatchEnrollAcceptResponseDTO
 import com.catchmate.data.dto.enroll.PatchEnrollRejectResponseDTO
 import com.catchmate.data.dto.enroll.PostEnrollRequestDTO
@@ -34,6 +35,11 @@ interface EnrollService {
     suspend fun patchEnrollAccept(
         @Path("enrollId") enrollId: Long,
     ): Response<PatchEnrollAcceptResponseDTO?>
+
+    @GET("enrolls/{boardId}/description")
+    suspend fun getRequestedEnroll(
+        @Path("boardId") boardId: Long,
+    ): Response<GetRequestedEnrollResponseDTO?>
 
     @GET("enrolls/request")
     suspend fun getRequestedEnrollList(

--- a/CatchMate/data/src/main/java/com/catchmate/data/dto/board/BoardDTO.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/dto/board/BoardDTO.kt
@@ -16,5 +16,6 @@ data class BoardDTO(
     val liftUpDate: String,
     val userInfo: UserInfoDTO,
     val buttonStatus: String?,
+    val chatRoomId: Long,
     val bookMarked: Boolean,
 )

--- a/CatchMate/data/src/main/java/com/catchmate/data/dto/board/GetBoardResponseDTO.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/dto/board/GetBoardResponseDTO.kt
@@ -16,5 +16,6 @@ data class GetBoardResponseDTO(
     val gameInfo: GameInfoDTO,
     val userInfo: UserInfoDTO,
     val buttonStatus: String,
+    val chatRoomId: Long,
     val bookMarked: Boolean,
 )

--- a/CatchMate/data/src/main/java/com/catchmate/data/dto/enroll/GetRequestedEnrollResponseDTO.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/dto/enroll/GetRequestedEnrollResponseDTO.kt
@@ -1,0 +1,6 @@
+package com.catchmate.data.dto.enroll
+
+data class GetRequestedEnrollResponseDTO(
+    val enrollId: Long,
+    val description: String,
+)

--- a/CatchMate/data/src/main/java/com/catchmate/data/mapper/BoardMapper.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/mapper/BoardMapper.kt
@@ -161,6 +161,7 @@ object BoardMapper {
             liftUpDate = dto.liftUpDate,
             userInfo = toUserInfo(dto.userInfo),
             buttonStatus = dto.buttonStatus,
+            chatRoomId = dto.chatRoomId,
             bookMarked = dto.bookMarked,
         )
 

--- a/CatchMate/data/src/main/java/com/catchmate/data/mapper/BoardMapper.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/mapper/BoardMapper.kt
@@ -187,6 +187,7 @@ object BoardMapper {
             gameInfo = toGameInfo(responseDTO.gameInfo),
             userInfo = toUserInfo(responseDTO.userInfo),
             buttonStatus = responseDTO.buttonStatus,
+            chatRoomId = responseDTO.chatRoomId,
             bookMarked = responseDTO.bookMarked,
         )
 

--- a/CatchMate/data/src/main/java/com/catchmate/data/mapper/EnrollMapper.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/mapper/EnrollMapper.kt
@@ -8,6 +8,7 @@ import com.catchmate.data.dto.enroll.GetAllReceivedEnrollResponseDTO
 import com.catchmate.data.dto.enroll.GetEnrollNewCountResponseDTO
 import com.catchmate.data.dto.enroll.GetReceivedEnrollResponseDTO
 import com.catchmate.data.dto.enroll.GetRequestedEnrollListResponseDTO
+import com.catchmate.data.dto.enroll.GetRequestedEnrollResponseDTO
 import com.catchmate.data.dto.enroll.PatchEnrollAcceptResponseDTO
 import com.catchmate.data.dto.enroll.PatchEnrollRejectResponseDTO
 import com.catchmate.data.dto.enroll.PostEnrollRequestDTO
@@ -23,6 +24,7 @@ import com.catchmate.domain.model.enroll.GetAllReceivedEnrollResponse
 import com.catchmate.domain.model.enroll.GetEnrollNewCountResponse
 import com.catchmate.domain.model.enroll.GetReceivedEnrollResponse
 import com.catchmate.domain.model.enroll.GetRequestedEnrollListResponse
+import com.catchmate.domain.model.enroll.GetRequestedEnrollResponse
 import com.catchmate.domain.model.enroll.PatchEnrollAcceptResponse
 import com.catchmate.domain.model.enroll.PatchEnrollRejectResponse
 import com.catchmate.domain.model.enroll.PostEnrollRequest
@@ -53,6 +55,12 @@ object EnrollMapper {
         PatchEnrollAcceptResponse(
             enrollId = responseDTO.enrollId,
             acceptStatus = responseDTO.acceptStatus,
+        )
+
+    fun toGetRequestedEnrollResponse(dto: GetRequestedEnrollResponseDTO): GetRequestedEnrollResponse =
+        GetRequestedEnrollResponse(
+            enrollId = dto.enrollId,
+            description = dto.description,
         )
 
     fun toGetRequestedEnrollListResponse(responseDTO: GetRequestedEnrollListResponseDTO): GetRequestedEnrollListResponse =

--- a/CatchMate/data/src/main/java/com/catchmate/data/mapper/NotificationMapper.kt
+++ b/CatchMate/data/src/main/java/com/catchmate/data/mapper/NotificationMapper.kt
@@ -1,21 +1,14 @@
 package com.catchmate.data.mapper
 
-import com.catchmate.data.dto.board.BoardDTO
-import com.catchmate.data.dto.enroll.GameInfoDTO
-import com.catchmate.data.dto.enroll.UserInfoDTO
 import com.catchmate.data.dto.notification.DeleteReceivedNotificationResponseDTO
 import com.catchmate.data.dto.notification.GetReceivedNotificationListResponseDTO
 import com.catchmate.data.dto.notification.GetReceivedNotificationResponseDTO
 import com.catchmate.data.dto.notification.NotificationInfoDTO
-import com.catchmate.data.dto.user.FavoriteClubDTO
-import com.catchmate.domain.model.board.Board
-import com.catchmate.domain.model.enroll.GameInfo
-import com.catchmate.domain.model.enroll.UserInfo
+import com.catchmate.data.mapper.BoardMapper.toBoard
 import com.catchmate.domain.model.notification.DeleteReceivedNotificationResponse
 import com.catchmate.domain.model.notification.GetReceivedNotificationListResponse
 import com.catchmate.domain.model.notification.GetReceivedNotificationResponse
 import com.catchmate.domain.model.notification.NotificationInfo
-import com.catchmate.domain.model.user.FavoriteClub
 
 object NotificationMapper {
     fun toGetReceivedNotificationListResponse(responseDTO: GetReceivedNotificationListResponseDTO): GetReceivedNotificationListResponse =
@@ -37,55 +30,6 @@ object NotificationMapper {
             createdAt = dto.createdAt,
             acceptStatus = dto.acceptStatus,
             read = dto.read,
-        )
-
-    private fun toBoard(dto: BoardDTO): Board =
-        Board(
-            boardId = dto.boardId,
-            title = dto.title,
-            content = dto.content,
-            cheerClubId = dto.cheerClubId,
-            currentPerson = dto.currentPerson,
-            maxPerson = dto.maxPerson,
-            preferredGender = dto.preferredGender,
-            preferredAgeRange = dto.preferredAgeRange,
-            gameInfo = toGameInfo(dto.gameInfo),
-            liftUpDate = dto.liftUpDate,
-            userInfo = toUserInfo(dto.userInfo),
-            buttonStatus = dto.buttonStatus,
-            bookMarked = dto.bookMarked,
-        )
-
-    private fun toGameInfo(dto: GameInfoDTO): GameInfo =
-        GameInfo(
-            homeClubId = dto.homeClubId,
-            awayClubId = dto.awayClubId,
-            gameStartDate = dto.gameStartDate,
-            location = dto.location,
-        )
-
-    private fun toUserInfo(dto: UserInfoDTO): UserInfo =
-        UserInfo(
-            userId = dto.userId,
-            email = dto.email,
-            profileImageUrl = dto.profileImageUrl,
-            gender = dto.gender,
-            allAlarm = dto.allAlarm,
-            chatAlarm = dto.chatAlarm,
-            enrollAlarm = dto.enrollAlarm,
-            eventAlarm = dto.eventAlarm,
-            nickName = dto.nickName,
-            favoriteClub = toFavoriteClub(dto.favoriteClub),
-            birthDate = dto.birthDate,
-            watchStyle = dto.watchStyle,
-        )
-
-    private fun toFavoriteClub(dto: FavoriteClubDTO): FavoriteClub =
-        FavoriteClub(
-            id = dto.id,
-            name = dto.name,
-            homeStadium = dto.homeStadium,
-            region = dto.region,
         )
 
     fun toGetReceivedNotificationResponse(dto: GetReceivedNotificationResponseDTO): GetReceivedNotificationResponse =

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/model/board/Board.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/model/board/Board.kt
@@ -19,5 +19,6 @@ data class Board(
     val liftUpDate: String,
     val userInfo: UserInfo,
     val buttonStatus: String?,
+    val chatRoomId: Long,
     val bookMarked: Boolean,
 ) : Parcelable

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/model/board/GetBoardResponse.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/model/board/GetBoardResponse.kt
@@ -19,5 +19,6 @@ data class GetBoardResponse(
     val gameInfo: GameInfo,
     val userInfo: UserInfo,
     val buttonStatus: String,
+    val chatRoomId: Long,
     val bookMarked: Boolean,
 ) : Parcelable

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/model/enroll/GetRequestedEnrollResponse.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/model/enroll/GetRequestedEnrollResponse.kt
@@ -1,0 +1,6 @@
+package com.catchmate.domain.model.enroll
+
+data class GetRequestedEnrollResponse(
+    val enrollId: Long,
+    val description: String,
+)

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/repository/EnrollRepository.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/repository/EnrollRepository.kt
@@ -5,6 +5,7 @@ import com.catchmate.domain.model.enroll.GetAllReceivedEnrollResponse
 import com.catchmate.domain.model.enroll.GetEnrollNewCountResponse
 import com.catchmate.domain.model.enroll.GetReceivedEnrollResponse
 import com.catchmate.domain.model.enroll.GetRequestedEnrollListResponse
+import com.catchmate.domain.model.enroll.GetRequestedEnrollResponse
 import com.catchmate.domain.model.enroll.PatchEnrollAcceptResponse
 import com.catchmate.domain.model.enroll.PatchEnrollRejectResponse
 import com.catchmate.domain.model.enroll.PostEnrollRequest
@@ -19,6 +20,8 @@ interface EnrollRepository {
     suspend fun patchEnrollReject(enrollId: Long): Result<PatchEnrollRejectResponse>
 
     suspend fun patchEnrollAccept(enrollId: Long): Result<PatchEnrollAcceptResponse>
+
+    suspend fun getRequestedEnroll(boardId: Long): Result<GetRequestedEnrollResponse>
 
     suspend fun getRequestedEnrollList(page: Int): Result<GetRequestedEnrollListResponse>
 

--- a/CatchMate/domain/src/main/java/com/catchmate/domain/usecase/enroll/GetRequestedEnrollUseCase.kt
+++ b/CatchMate/domain/src/main/java/com/catchmate/domain/usecase/enroll/GetRequestedEnrollUseCase.kt
@@ -1,0 +1,13 @@
+package com.catchmate.domain.usecase.enroll
+
+import com.catchmate.domain.model.enroll.GetRequestedEnrollResponse
+import com.catchmate.domain.repository.EnrollRepository
+import javax.inject.Inject
+
+class GetRequestedEnrollUseCase
+    @Inject
+    constructor(
+        private val enrollRepository: EnrollRepository,
+    ) {
+        suspend operator fun invoke(boardId: Long): Result<GetRequestedEnrollResponse> = enrollRepository.getRequestedEnroll(boardId)
+    }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/AddPostFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/AddPostFragment.kt
@@ -367,14 +367,7 @@ class AddPostFragment :
         addPostViewModel.patchBoardResponse.observe(viewLifecycleOwner) { response ->
             if (response != null) {
                 Log.d("boardEditResponse", response.boardId.toString())
-                val bundle = Bundle()
-                bundle.putLong("boardId", response.boardId)
-                val navOptions =
-                    NavOptions
-                        .Builder()
-                        .setPopUpTo(R.id.addPostFragment, true)
-                        .build()
-                findNavController().navigate(R.id.action_addPostFragment_to_readPostFragment, bundle, navOptions)
+                findNavController().popBackStack()
             }
         }
     }
@@ -591,6 +584,7 @@ class AddPostFragment :
                             tempBoard.gameInfo,
                             tempBoard.userInfo,
                             "",
+                            -1L,
                             false,
                         )
                     addPostViewModel.setBoardInfo(board)

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/PostCheerTeamBottomSheetFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/PostCheerTeamBottomSheetFragment.kt
@@ -83,15 +83,18 @@ class PostCheerTeamBottomSheetFragment(
     }
 
     private fun initFooter() {
-        binding.layoutFooterPostCheerTeam.btnFooterOne.setOnClickListener {
-            cheerTeamSelectedListener?.onCheerTeamSelected(
-                selectedButton
-                    ?.binding
-                    ?.tvTeamToggleCheckButton
-                    ?.text
-                    .toString(),
-            )
-            dismiss()
+        binding.layoutFooterPostCheerTeam.btnFooterOne.apply {
+            text = getString(R.string.complete)
+            setOnClickListener {
+                cheerTeamSelectedListener?.onCheerTeamSelected(
+                    selectedButton
+                        ?.binding
+                        ?.tvTeamToggleCheckButton
+                        ?.text
+                        .toString(),
+                )
+                dismiss()
+            }
         }
     }
 

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/ReadPostFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/ReadPostFragment.kt
@@ -194,7 +194,11 @@ class ReadPostFragment : Fragment() {
                         // 신청 확인 버튼 클릭 시 내가 보낸 신청 목록 불러오는 api 호출 후 옵저버에서 신청 정보 다이얼로그 표시 처리
                         readPostViewModel.getRequestedEnrollList(boardId)
                     }
-                    EnrollState.VIEW_CHAT -> {} // 채팅 화면으로 이동
+                    EnrollState.VIEW_CHAT -> {
+                        val bundle = Bundle()
+                        bundle.putLong("chatRoomId", readPostViewModel.getBoardResponse.value?.chatRoomId!!)
+                        findNavController().navigate(R.id.action_readPostFragment_to_chattingRoomFragment, bundle)
+                    }
                     null -> {}
                 }
             }

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/ReadPostFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/ReadPostFragment.kt
@@ -210,6 +210,12 @@ class ReadPostFragment : Fragment() {
         readPostViewModel.getBoardResponse.observe(viewLifecycleOwner) { response ->
             setPostData(response)
             isWriter = response.userInfo.userId == userId
+            if (response.maxPerson == response.currentPerson) {
+                binding.layoutReadPostFooter.btnLikedFooterRegister.apply {
+                    text = getString(R.string.post_register_closed)
+                    isEnabled = false
+                }
+            }
         }
 
         readPostViewModel.postBoardLikeResponse.observe(viewLifecycleOwner) { code ->

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/ReadPostFragment.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/view/post/ReadPostFragment.kt
@@ -191,8 +191,8 @@ class ReadPostFragment : Fragment() {
                 when (readPostViewModel.boardEnrollState.value) {
                     EnrollState.APPLY -> showEnrollDialog()
                     EnrollState.APPLIED -> {
-                        // 신청 확인 버튼 클릭 시 내가 보낸 신청 목록 불러오는 api 호출 후 옵저버에서 신청 정보 다이얼로그 표시 처리
-                        readPostViewModel.getRequestedEnrollList(boardId)
+                        // 신청 확인 버튼 클릭 시 내가 보낸 신청 불러오는 api 호출 후 옵저버에서 신청 정보 다이얼로그 표시 처리
+                        readPostViewModel.getRequestedEnroll(boardId)
                     }
                     EnrollState.VIEW_CHAT -> {
                         val bundle = Bundle()
@@ -261,8 +261,8 @@ class ReadPostFragment : Fragment() {
                 findNavController().popBackStack()
             }
         }
-        readPostViewModel.getRequestedEnroll.observe(viewLifecycleOwner) { enrollInfo ->
-            if (enrollInfo != null) {
+        readPostViewModel.getRequestedEnroll.observe(viewLifecycleOwner) { response ->
+            if (response != null) {
                 showEnrollRequestDialog()
             }
         }
@@ -506,15 +506,16 @@ class ReadPostFragment : Fragment() {
 
         dialogBinding.apply {
             val enrollInfo = readPostViewModel.getRequestedEnroll.value!!
+            val boardInfo = readPostViewModel.getBoardResponse.value!!
 
-            val dateTimePair = DateUtils.formatISODateTimeToDateTime(enrollInfo.boardInfo.gameInfo.gameStartDate!!)
+            val dateTimePair = DateUtils.formatISODateTimeToDateTime(boardInfo.gameInfo.gameStartDate!!)
             tvApplicationDetailDialogDate.text = dateTimePair.first
             tvApplicationDetailDialogTime.text = dateTimePair.second
-            tvApplicationDetailDialogPlace.text = enrollInfo.boardInfo.gameInfo.location
+            tvApplicationDetailDialogPlace.text = boardInfo.gameInfo.location
 
-            val isCheerTeam = enrollInfo.boardInfo.gameInfo.homeClubId == enrollInfo.boardInfo.cheerClubId
+            val isCheerTeam = boardInfo.gameInfo.homeClubId == boardInfo.cheerClubId
             setTeamViewResources(
-                enrollInfo.boardInfo.gameInfo.homeClubId,
+                boardInfo.gameInfo.homeClubId,
                 isCheerTeam,
                 ivApplicationDetailDialogHomeTeamBg,
                 ivApplicationDetailDialogHomeTeamLogo,
@@ -522,7 +523,7 @@ class ReadPostFragment : Fragment() {
                 requireContext(),
             )
             setTeamViewResources(
-                enrollInfo.boardInfo.gameInfo.awayClubId,
+                boardInfo.gameInfo.awayClubId,
                 !isCheerTeam,
                 ivApplicationDetailDialogAwayTeamBg,
                 ivApplicationDetailDialogAwayTeamLogo,

--- a/CatchMate/presentation/src/main/java/com/catchmate/presentation/viewmodel/ReadPostViewModel.kt
+++ b/CatchMate/presentation/src/main/java/com/catchmate/presentation/viewmodel/ReadPostViewModel.kt
@@ -12,7 +12,7 @@ import com.catchmate.domain.model.board.GetBoardResponse
 import com.catchmate.domain.model.board.PatchBoardLiftUpResponse
 import com.catchmate.domain.model.board.PostBoardLikeResponse
 import com.catchmate.domain.model.enroll.DeleteEnrollResponse
-import com.catchmate.domain.model.enroll.EnrollInfo
+import com.catchmate.domain.model.enroll.GetRequestedEnrollResponse
 import com.catchmate.domain.model.enroll.PostEnrollRequest
 import com.catchmate.domain.model.enroll.PostEnrollResponse
 import com.catchmate.domain.model.enumclass.EnrollState
@@ -22,7 +22,7 @@ import com.catchmate.domain.usecase.board.GetBoardUseCase
 import com.catchmate.domain.usecase.board.PatchBoardLiftUpUseCase
 import com.catchmate.domain.usecase.board.PostBoardLikeUseCase
 import com.catchmate.domain.usecase.enroll.DeleteEnrollUseCase
-import com.catchmate.domain.usecase.enroll.GetRequestedEnrollListUseCase
+import com.catchmate.domain.usecase.enroll.GetRequestedEnrollUseCase
 import com.catchmate.domain.usecase.enroll.PostEnrollUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -38,7 +38,7 @@ class ReadPostViewModel
         private val deleteBoardLikeUseCase: DeleteBoardLikeUseCase,
         private val postEnrollUseCase: PostEnrollUseCase,
         private val patchBoardLiftUpUseCase: PatchBoardLiftUpUseCase,
-        private val getRequestedEnrollListUseCase: GetRequestedEnrollListUseCase,
+        private val getRequestedEnrollUseCase: GetRequestedEnrollUseCase,
         private val deleteEnrollUseCase: DeleteEnrollUseCase,
     ) : ViewModel() {
         private val _getBoardResponse = MutableLiveData<GetBoardResponse>()
@@ -69,8 +69,8 @@ class ReadPostViewModel
         val patchBoardLiftUpResponse: LiveData<PatchBoardLiftUpResponse>
             get() = _patchBoardLiftUpResponse
 
-        private val _getRequestedEnroll = MutableLiveData<EnrollInfo>()
-        val getRequestedEnroll: LiveData<EnrollInfo>
+        private val _getRequestedEnroll = MutableLiveData<GetRequestedEnrollResponse>()
+        val getRequestedEnroll: LiveData<GetRequestedEnrollResponse>
             get() = _getRequestedEnroll
 
         private val _deleteEnrollResponse = MutableLiveData<DeleteEnrollResponse>()
@@ -194,14 +194,12 @@ class ReadPostViewModel
             }
         }
 
-        fun getRequestedEnrollList(boardId: Long) {
+        fun getRequestedEnroll(boardId: Long) {
             viewModelScope.launch {
-                val result = getRequestedEnrollListUseCase.getRequestedEnrollList(0)
+                val result = getRequestedEnrollUseCase(boardId)
                 result
                     .onSuccess { response ->
-                        for (enrollInfo in response.enrollInfoList) {
-                            if (enrollInfo.boardInfo.boardId == boardId) _getRequestedEnroll.value = enrollInfo
-                        }
+                        _getRequestedEnroll.value = response
                     }.onFailure { exception ->
                         when (exception) {
                             is ReissueFailureException -> {

--- a/CatchMate/presentation/src/main/res/navigation/nav_graph.xml
+++ b/CatchMate/presentation/src/main/res/navigation/nav_graph.xml
@@ -99,6 +99,9 @@
         <action
             android:id="@+id/action_readPostFragment_to_loginFragment"
             app:destination="@id/loginFragment" />
+        <action
+            android:id="@+id/action_readPostFragment_to_chattingRoomFragment"
+            app:destination="@id/chattingRoomFragment" />
     </fragment>
     <fragment
         android:id="@+id/myPageFragment"

--- a/CatchMate/presentation/src/main/res/values/strings-post.xml
+++ b/CatchMate/presentation/src/main/res/values/strings-post.xml
@@ -16,6 +16,7 @@
     <string name="temporary_storage">임시저장</string>
     <string name="post_complete">작성 완료</string>
     <string name="post_register">직관 신청</string>
+    <string name="post_register_closed">신청 마감</string>
     <string name="post_check_register">보낸 신청 보기</string>
     <string name="post_writer">채팅 보기</string>
 


### PR DESCRIPTION
## 작업 내용
<버그 수정>
- 구단 선택 필터 다이얼로그 하단 버튼 텍스트 설정
- 게시글 수정 완료 시 페이지 이동\

<기능 구현>
- 버튼 상태 VIEW_CHAT일 때 채팅방 이동 로직
- 모집 인원 마감 시 버튼 비활성화
- 서버 수정에 의해 보낸 신청 조회 시 목록 아닌 단일 조회 api 호출
<br>

## 참고 사항
<br>
